### PR TITLE
Stop notifications from moving page context

### DIFF
--- a/weblab/static/sass/style.scss
+++ b/weblab/static/sass/style.scss
@@ -7,6 +7,8 @@
 @import "displayTable/displayTable";
 @import "editMetadata/editMetadata";
 
+$page-width: 850px;
+
 body {
 	font-family: 'Open Sans', sans-serif;
 	font-size: 16px;
@@ -17,7 +19,7 @@ code,input {
 }
 
 #page {
-	width: 850px;
+	width: $page-width;
 	margin: auto;
 }
 
@@ -221,6 +223,11 @@ form {
     list-style-type: none;
     padding-left: 0;
   }
+}
+
+#notifications {
+    position: absolute;
+    width: $page-width;
 }
 
 #error {


### PR DESCRIPTION
Fixes #70. I've gone for the simple approach of just making the notification box sit on top of the main content. It will grow indefinitely as new errors/notes are added, until dismissed.