### PR TITLE
Improve performance of matrix view

### DIFF
--- a/requirements/Makefile
+++ b/requirements/Makefile
@@ -1,12 +1,14 @@
 .PHONY: all check clean
 
+upgrade_flag = #-U
+
 objects = $(wildcard *.in)
 outputs := $(objects:.in=.txt)
 
 all: $(outputs)
 
 %.txt: %.in
-	pip-compile -v --output-file $@ $<
+	pip-compile -v $(upgrade_flag) --output-file $@ $<
 
 test.txt: base.txt
 

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -16,4 +16,4 @@ GitPython==2.1.7
 django-braces==1.11.0
 
 # Server monitoring
-rollbar
+rollbar==0.14.2

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -20,7 +20,7 @@ python3-openid==3.1.0     # via social-auth-core
 pytz==2017.2              # via django
 requests-oauthlib==0.8.0  # via social-auth-core
 requests==2.18.4          # via requests-oauthlib, rollbar, social-auth-core
-rollbar==0.13.18
+rollbar==0.14.2
 six==1.10.0               # via rollbar, social-auth-app-django, social-auth-core
 smmap2==2.0.3             # via gitdb2
 social-auth-app-django==1.2.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -45,7 +45,7 @@ python3-openid==3.1.0     # via social-auth-core
 pytz==2017.2              # via django
 requests-oauthlib==0.8.0  # via social-auth-core
 requests==2.18.4          # via codecov, requests-oauthlib, rollbar, social-auth-core
-rollbar==0.13.18
+rollbar==0.14.2
 simplegeneric==0.8.1      # via ipython
 six==1.10.0               # via model-mommy, pip-tools, prompt-toolkit, rollbar, social-auth-app-django, social-auth-core, traitlets
 smmap2==2.0.3             # via gitdb2

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -27,7 +27,7 @@ python3-openid==3.1.0     # via social-auth-core
 pytz==2017.2              # via django
 requests-oauthlib==0.8.0  # via social-auth-core
 requests==2.18.4          # via codecov, requests-oauthlib, rollbar, social-auth-core
-rollbar==0.13.18
+rollbar==0.14.2
 six==1.10.0               # via model-mommy, rollbar, social-auth-app-django, social-auth-core
 smmap2==2.0.3             # via gitdb2
 social-auth-app-django==1.2.0

--- a/weblab/entities/models.py
+++ b/weblab/entities/models.py
@@ -38,8 +38,13 @@ class Entity(UserCreatedModelMixin, VisibilityModelMixin, models.Model):
     def __str__(self):
         return self.name
 
-    @cached_property
+    @property
     def repo(self):
+        """This entity's git repository wrapper.
+
+        Note that we do not cache this property as this can lead to too many open files.
+        See also https://gitpython.readthedocs.io/en/stable/intro.html#leakage-of-system-resources
+        """
         return Repository(self.repo_abs_path)
 
     @property

--- a/weblab/experiments/views.py
+++ b/weblab/experiments/views.py
@@ -46,9 +46,9 @@ class ExperimentMatrixJsonView(View):
             version = commit.hexsha if commit else ''
             name = entity.name
         else:
-            name = '%s @ %s' % (entity.name, entity.nice_version(version))
+            name = '%s @ %s' % (entity.name, version)
 
-        friendly_version = entity.repo.get_name_for_commit(version) if version else ''
+        friendly_version = version if version else ''
 
         _json = {
             'id': version,


### PR DESCRIPTION
Work on #73. Basically, accessing the git repos is slow, so this tries to avoid doing so where possible. I've also avoided caching the repo wrapper class, which will hopefully avoid running out of file handles! It's certainly made an improvement on scrambler - not quite as fast as WL1 (which can generate the view purely from DB queries) but much closer. I think now it only hits the filesystem for the row & column labels, not for each experiment.

We may wish to think @helenst about caching some bits of git metadata within the DB for speed - perhaps in a later phase once features for #68 are done. I'm thinking the list of commit SHAs and tags, perhaps also visibility stuff for #41 ? Provided all updates to the local repos on the server are mediated through Django (i.e. we don't allow direct push) it should be possible to keep things in sync, and we could have a cron job that re-syncs just in case.