### PR TITLE
Add visibility field to new version form

### DIFF
--- a/weblab/entities/forms.py
+++ b/weblab/entities/forms.py
@@ -42,6 +42,10 @@ class ProtocolEntityForm(EntityForm):
 
 
 class EntityVersionForm(forms.Form):
+    visibility = forms.ChoiceField(
+        choices=visibility.CHOICES,
+        help_text=visibility.HELP_TEXT.replace('\n', '<br />'),
+    )
     tag = forms.CharField(
         help_text='Optional short label for this version',
         required=False)

--- a/weblab/entities/tests/test_views.py
+++ b/weblab/entities/tests/test_views.py
@@ -554,11 +554,12 @@ class TestEntityList:
 class TestVersionCreation:
     def test_new_version_form_includes_latest_version(self, client, user, helpers):
         model = recipes.model.make()
-        commit = helpers.add_version(model)
+        commit = helpers.add_version(model, visibility='public')
         add_permission(user, 'create_model_version')
         response = client.get('/entities/models/%d/versions/new' % model.pk)
         assert response.status_code == 200
         assert response.context['latest_version'] == commit
+        assert b'option value="public" selected' in response.content
 
     def test_no_latest_version(self, client, user):
         add_permission(user, 'create_model_version')
@@ -566,6 +567,7 @@ class TestVersionCreation:
         response = client.get('/entities/models/%d/versions/new' % model.pk)
         assert response.status_code == 200
         assert 'latest_version' not in response.context
+        assert b'option value="private" selected' in response.content
 
     def test_create_model_version(self, user, client):
         add_permission(user, 'create_model_version')

--- a/weblab/entities/views.py
+++ b/weblab/entities/views.py
@@ -389,6 +389,7 @@ class EntityNewVersionView(
         delete_file = self.request.GET.get('deletefile')
         if delete_file:
             initial['commit_message'] = 'Delete %s' % delete_file
+        initial['visibility'] = self.get_object().visibility
         return initial
 
     def get_context_data(self, **kwargs):


### PR DESCRIPTION
I discovered #83 meant you couldn't create new versions of entities any more! This fixes that.

Child of #68.