### PR TITLE
Ensure data deleted when experiment deleted

### DIFF
--- a/weblab/conftest.py
+++ b/weblab/conftest.py
@@ -109,6 +109,20 @@ def queued_experiment(model_with_version, protocol_with_version):
 
 
 @pytest.fixture
+def experiment_with_result(model_with_version, protocol_with_version):
+    version = recipes.experiment_version.make(
+        status='SUCCESS',
+        experiment__model=model_with_version,
+        experiment__protocol=protocol_with_version,
+    )
+    version.abs_path.mkdir()
+    with (version.abs_path / 'result.txt').open('w') as f:
+        f.write('experiment results')
+    return version
+
+
+
+@pytest.fixture
 def experiment_version(public_model, public_protocol):
     return recipes.experiment_version.make(
         status='SUCCESS',

--- a/weblab/entities/tests/test_models.py
+++ b/weblab/entities/tests/test_models.py
@@ -27,7 +27,7 @@ class TestEntityNameUniqueness:
 
 
 @pytest.mark.django_db
-def test_deletion():
+def test_deletion_permissions():
     user, other_user = recipes.user.make(_quantity=2)
     model = recipes.model.make(author=user)
     superuser = recipes.user.make(is_superuser=True)
@@ -160,3 +160,11 @@ class TestEntity:
         assert model.repo.tag_dict[sha][0].name == 'mytag'
 
         assert model.get_tags(sha) == {'mytag'}
+
+    def test_entity_repo_is_deleted_when_entity_is_deleted(self, model_with_version):
+        repo_path = model_with_version.repo_abs_path
+        assert repo_path.exists()
+
+        model_with_version.delete()
+
+        assert not repo_path.exists()

--- a/weblab/experiments/__init__.py
+++ b/weblab/experiments/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'experiments.apps.ExperimentsConfig'

--- a/weblab/experiments/apps.py
+++ b/weblab/experiments/apps.py
@@ -1,5 +1,13 @@
 from django.apps import AppConfig
+from django.db.models.signals import pre_delete
+
+from .signals import experiment_version_deleted
 
 
 class ExperimentsConfig(AppConfig):
     name = 'experiments'
+
+    def ready(self):
+        from .models import ExperimentVersion
+
+        pre_delete.connect(experiment_version_deleted, ExperimentVersion)

--- a/weblab/experiments/signals.py
+++ b/weblab/experiments/signals.py
@@ -1,0 +1,10 @@
+from shutil import rmtree
+
+
+def experiment_version_deleted(sender, instance, **kwargs):
+    """
+    Signal callback when an experiment version is about to be deleted.
+
+    Ensure the experiment data directory is also deleted.
+    """
+    rmtree(str(instance.abs_path))

--- a/weblab/experiments/tests/test_models.py
+++ b/weblab/experiments/tests/test_models.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 from core import recipes
+from experiments.models import Experiment, ExperimentVersion
 
 
 @pytest.fixture
@@ -102,6 +103,27 @@ class TestExperiment:
 
         exp.protocol.add_collaborator(user)
         assert user in exp.viewers
+
+    def test_data_is_deleted_when_experiment_is_deleted(self, experiment_with_result):
+        exp_path = experiment_with_result.abs_path
+
+        assert exp_path.exists()
+
+        experiment_with_result.delete()
+
+        assert not exp_path.exists()
+
+    def test_experiment_is_deleted_when_model_is_deleted(self, experiment_with_result):
+        experiment_id = experiment_with_result.experiment.id
+        version_id = experiment_with_result.id
+        exp_path = experiment_with_result.abs_path
+        assert exp_path.exists()
+
+        experiment_with_result.experiment.model.delete()
+
+        assert not Experiment.objects.filter(id=experiment_id).exists()
+        assert not ExperimentVersion.objects.filter(id=version_id).exists()
+        assert not exp_path.exists()
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Ensure related experiments are deleted when an entity is deleted. (This was already the case, but here we add tests to check this). Delete the experiment data directory upon deletion.

Also added tests to ensure entity repo is deleted on entity deletion.

Fixes #66 