### PR TITLE
Cancel experiment runs when deleted

### DIFF
--- a/weblab/experiments/apps.py
+++ b/weblab/experiments/apps.py
@@ -1,13 +1,14 @@
 from django.apps import AppConfig
 from django.db.models.signals import pre_delete
 
-from .signals import experiment_version_deleted
+from .signals import experiment_version_deleted, running_experiment_deleted
 
 
 class ExperimentsConfig(AppConfig):
     name = 'experiments'
 
     def ready(self):
-        from .models import ExperimentVersion
+        from .models import ExperimentVersion, RunningExperiment
 
         pre_delete.connect(experiment_version_deleted, ExperimentVersion)
+        pre_delete.connect(running_experiment_deleted, RunningExperiment)

--- a/weblab/experiments/processing.py
+++ b/weblab/experiments/processing.py
@@ -114,6 +114,22 @@ def submit_experiment(model, model_version, protocol, protocol_version, user):
     return version
 
 
+def cancel_experiment(task_id):
+    """Cancel the Celery task for an experiment.
+
+    @param task_id  the Celery task id of the experiment to cancel
+    """
+    body = {
+        'cancelTask': task_id,
+        'password': settings.CHASTE_PASSWORD,
+    }
+
+    try:
+        requests.post(settings.CHASTE_URL, body)
+    except requests.exceptions.ConnectionError:
+        logger.exception("Unable to cancel experiment")
+
+
 def process_callback(data, files):
     signature = data.get('signature')
     if not signature:

--- a/weblab/experiments/signals.py
+++ b/weblab/experiments/signals.py
@@ -6,8 +6,11 @@ def experiment_version_deleted(sender, instance, **kwargs):
     Signal callback when an experiment version is about to be deleted.
 
     Ensure the experiment data directory is also deleted.
+
+    If the directory doesn't exist yet (because no results received) this is a no-op.
     """
-    rmtree(str(instance.abs_path))
+    if instance.abs_path.is_dir():
+        rmtree(str(instance.abs_path))
 
 
 def running_experiment_deleted(sender, instance, **kwargs):

--- a/weblab/experiments/signals.py
+++ b/weblab/experiments/signals.py
@@ -8,3 +8,12 @@ def experiment_version_deleted(sender, instance, **kwargs):
     Ensure the experiment data directory is also deleted.
     """
     rmtree(str(instance.abs_path))
+
+
+def running_experiment_deleted(sender, instance, **kwargs):
+    """Signal handler for deleting a queued or running experiment.
+
+    Will cancel the associated celery task to free up resources.
+    """
+    from .processing import cancel_experiment
+    cancel_experiment(instance.task_id)

--- a/weblab/experiments/signals.py
+++ b/weblab/experiments/signals.py
@@ -15,5 +15,6 @@ def running_experiment_deleted(sender, instance, **kwargs):
 
     Will cancel the associated celery task to free up resources.
     """
-    from .processing import cancel_experiment
-    cancel_experiment(instance.task_id)
+    if instance.task_id:
+        from .processing import cancel_experiment
+        cancel_experiment(instance.task_id)


### PR DESCRIPTION
Will fix #106.

Still need to:
- [x] test it really fixes the issue when deployed
- [x] don't call webservice if you're deleting a run that didn't start successfully!
- [x] fix tests: the patched `requests.post` doesn't cope with the cancel task call
- [x] add tests for new behaviour