### PR TITLE
Show more details about 'errors' on version pages

### DIFF
--- a/weblab/static/js/experiment.js
+++ b/weblab/static/js/experiment.js
@@ -288,9 +288,18 @@ function init() {
     //if (entityType == 'experiment')
     //{
     if (v.status == 'RUNNING' || v.status == 'QUEUED')
+    {
       dv.exptRunningNote.style.display = "block";
+      $('#return-text').hide();
+    }
     else
+    {
       dv.exptRunningNote.style.display = "none";
+      if (v.status == 'SUCCESS')
+        $('#return-text').hide();
+      else
+        $('#return-text').show();
+    }
     dv.exptStatus.innerHTML = "Status: " + v.status + ".";
     //}
 

--- a/weblab/templates/experiments/experiment_versions.html
+++ b/weblab/templates/experiments/experiment_versions.html
@@ -45,7 +45,7 @@
           {% endwith %}
         </span><br />
         <span class="suppl">
-          {{ version.return_text|linebreaksbr|safe }}
+          {{ version.return_text|safe|linebreaksbr }}
         </span>
       </p>
     </li>

--- a/weblab/templates/experiments/experiment_versions.html
+++ b/weblab/templates/experiments/experiment_versions.html
@@ -25,11 +25,6 @@
 
   <h2>Versions</h2>
 
-  {% comment %}
-    <!-- TODO: Needs some JS code to make this work -->
-    <a id="rerunExperiment"><img src="{% static 'img/refresh.png' %}" alt="rerun experiment" title="rerun experiment"/>Re-run experiment</a> <span id="rerunExperimentAction"></span>
-  {% endcomment %}
-
   <div id="entityversionlist_content">
     <ul>
     {% for version in experiment.versions.all|dictsortreversed:"created_at" %}

--- a/weblab/templates/experiments/experiment_versions.html
+++ b/weblab/templates/experiments/experiment_versions.html
@@ -50,7 +50,7 @@
           {% endwith %}
         </span><br />
         <span class="suppl">
-          {{ version.return_text|linebreaksbr }}
+          {{ version.return_text|linebreaksbr|safe }}
         </span>
       </p>
     </li>

--- a/weblab/templates/experiments/experimentversion_detail.html
+++ b/weblab/templates/experiments/experimentversion_detail.html
@@ -61,7 +61,7 @@
     </div>
 
     <p id="return-text" class="experiment-{{ version.status }}" style="display:none;">
-      {{ version.return_text|linebreaksbr|safe }}
+      {{ version.return_text|safe|linebreaksbr }}
     </p>
 
     <div id="running-experiment-note" style="display:none;">

--- a/weblab/templates/experiments/experimentversion_detail.html
+++ b/weblab/templates/experiments/experimentversion_detail.html
@@ -60,6 +60,10 @@
       </small>
     </div>
 
+    <p id="return-text" class="experiment-{{ version.status }}" style="display:none;">
+      {{ version.return_text|linebreaksbr|safe }}
+    </p>
+
     <div id="running-experiment-note" style="display:none;">
       <p>
         This experiment has not yet finished running, and so no result files are available.


### PR DESCRIPTION
Show the experiment runner service return text if it might be 'interesting' (i.e. a completed non-successful experiment).

Fixes #122.