### PR TITLE
Add example links on home page for workshop

### DIFF
--- a/weblab/templates/home.html
+++ b/weblab/templates/home.html
@@ -15,7 +15,12 @@
   <h2>Quick start links</h2>
   <ul>
     <li><a href="{% url 'experiments:list' %}">View results of experiments</a> stored on this site.</li>
-    <li>Compare the results of different experiments, e.g. ...; or <a href="{% url 'experiments:list' %}">set up your own comparisons</a>.</li>
+    <li>Compare the results of different experiments, e.g.
+      <a href="{% url 'experiments:compare' '/413/1070/1069/422/1071' %}">dog models under 2Hz pacing</a>,
+      <a href="{% url 'experiments:compare' '/153/254/255/257/258/266/270/182/271/203/1063/279/280/281/283/265' %}">an IV curve of the fast sodium current</a>,
+      or <a href="{% url 'experiments:compare' '/38/135' %}">S1-S2 and steady state restitution</a>;
+      or <a href="{% url 'experiments:list' %}">set up your own comparisons</a>.</li>
+    <li>View <a href="/experiments/models/65/63/61/64/4/protocols/69/70/67/68/2/66">prototype parameter fitting results</a>.</li>
     {% if user.is_authenticated %}
       {% url 'entities:list' 'model' as analyse_link %}
     {% else %}


### PR DESCRIPTION
Fixes #50.

Note that these will only give sensible results on the production system, as they hardcode particular experiment ids.