### PR TITLE
Fix mis-match in superuser permissions

### DIFF
--- a/weblab/entities/models.py
+++ b/weblab/entities/models.py
@@ -246,7 +246,7 @@ class EntityManager(models.Manager):
 
     def with_edit_permission(self, user):
         if user.has_perm('entities.create_%s' % self.model.entity_type):
-            return get_objects_for_user(user, 'entities.edit_entity')
+            return get_objects_for_user(user, 'entities.edit_entity', with_superuser=False)
         else:
             return self.none()
 

--- a/weblab/entities/views.py
+++ b/weblab/entities/views.py
@@ -892,7 +892,7 @@ class GetProtocolInterfacesJsonView(View):
             visible_protocols = user.entity_set.filter(
                 entity_type='protocol'
             ).union(
-                get_objects_for_user(user, 'entities.edit_entity'),
+                get_objects_for_user(user, 'entities.edit_entity', with_superuser=False),
             ).values_list(
                 'id', flat=True
             )

--- a/weblab/experiments/views.py
+++ b/weblab/experiments/views.py
@@ -147,7 +147,7 @@ class ExperimentMatrixJsonView(View):
         if user.is_authenticated:
             # Can also include versions the user has explicit permission to see
             visible_entities = user.entity_set.union(
-                get_objects_for_user(user, 'entities.edit_entity')
+                get_objects_for_user(user, 'entities.edit_entity', with_superuser=False)
             ).values_list(
                 'id', flat=True
             )


### PR DESCRIPTION
`guardian.shortcuts.get_objects_for_user` shows all objects to superusers by default, whereas `get_users_with_perms(entity)` only yields users with explicit permissions. So superusers could see entities in some contexts but not others, depending on which method was used to check permissions.

This may be the issue Michael saw on #180...