### PR TITLE
Properly clean up storage folders

### DIFF
--- a/weblab/conftest.py
+++ b/weblab/conftest.py
@@ -1,5 +1,7 @@
 import datetime
+import os
 import uuid
+from pathlib import Path
 
 import pytest
 from django.contrib.auth.models import AnonymousUser, Permission
@@ -223,32 +225,38 @@ def moderated_experiment_version(moderated_model, moderated_protocol):
 
 @pytest.fixture
 def admin_user():
-    return User.objects.create_superuser(
+    user = User.objects.create_superuser(
         email='admin@example.com',
         full_name='Admin User',
         institution='UCL',
         password='password',
     )
+    yield user
+    user.clean_up_storage()
 
 
 @pytest.fixture
 def user():
-    return User.objects.create_user(
+    user = User.objects.create_user(
         email='test@example.com',
         full_name='Test User',
         institution='UCL',
         password='password',
     )
+    yield user
+    user.clean_up_storage()
 
 
 @pytest.fixture
 def other_user():
-    return User.objects.create_user(
+    user = User.objects.create_user(
         email='other@example.com',
         full_name='Other User',
         institution='UCL',
         password='password',
     )
+    yield user
+    user.clean_up_storage()
 
 
 @pytest.fixture

--- a/weblab/conftest.py
+++ b/weblab/conftest.py
@@ -107,7 +107,6 @@ class Helpers:
         return dataset
 
 
-
 @pytest.fixture
 def helpers():
     """
@@ -194,7 +193,7 @@ def experiment_with_result(model_with_version, protocol_with_version):
         experiment__model=model_with_version,
         experiment__protocol=protocol_with_version,
     )
-    version.abs_path.mkdir()
+    version.mkdir()
     with (version.abs_path / 'result.txt').open('w') as f:
         f.write('experiment results')
     return version

--- a/weblab/conftest.py
+++ b/weblab/conftest.py
@@ -119,19 +119,20 @@ def helpers():
 
 @pytest.fixture(autouse=True)
 def fake_upload_path(settings, tmpdir):
-    settings.MEDIA_ROOT = str(tmpdir)
+    # Note that at present (Python 3.5, Django 1.11) Django requires this to be a string
+    settings.MEDIA_ROOT = os.path.join(str(tmpdir), 'uploads')
     return settings.MEDIA_ROOT
 
 
 @pytest.fixture(autouse=True)
 def fake_experiment_path(settings, tmpdir):
-    settings.EXPERIMENT_BASE = str(tmpdir)
+    settings.EXPERIMENT_BASE = Path(str(tmpdir)) / 'experiments'
     return settings.EXPERIMENT_BASE
 
 
 @pytest.fixture(autouse=True)
 def fake_repo_path(settings, tmpdir):
-    settings.REPO_BASE = str(tmpdir)
+    settings.REPO_BASE = Path(str(tmpdir)) / 'repos'
     return settings.REPO_BASE
 
 

--- a/weblab/conftest.py
+++ b/weblab/conftest.py
@@ -136,6 +136,12 @@ def fake_repo_path(settings, tmpdir):
     return settings.REPO_BASE
 
 
+@pytest.fixture(autouse=True)
+def fake_dataset_path(settings, tmpdir):
+    settings.DATASETS_BASE = Path(str(tmpdir)) / 'datasets'
+    return settings.DATASETS_BASE
+
+
 @pytest.fixture
 def model_with_version():
     model = recipes.model.make()

--- a/weblab/datasets/models.py
+++ b/weblab/datasets/models.py
@@ -36,7 +36,7 @@ class Dataset(UserCreatedModelMixin, VisibilityModelMixin, models.Model):
 
     @property
     def abs_path(self):
-        return Path(settings.DATASETS_BASE, str(self.author.id), str(self.id))
+        return self.author.get_storage_dir('dataset') / str(self.id)
 
     @property
     def archive_name(self):

--- a/weblab/datasets/tests/test_views.py
+++ b/weblab/datasets/tests/test_views.py
@@ -47,7 +47,6 @@ class TestDatasetCreation:
         assert response.url == '/datasets/%d/addfiles' % dataset.id
         assert dataset.name == 'mydataset'
         assert dataset.author == logged_in_user
-        dataset.delete()
 
     def test_create_dataset_requires_permissions(self, logged_in_user, client):
         response = client.post(

--- a/weblab/entities/models.py
+++ b/weblab/entities/models.py
@@ -73,7 +73,7 @@ class Entity(UserCreatedModelMixin, models.Model):
         :return: `Path` object
         """
         return Path(
-            settings.REPO_BASE, str(self.author.id), '%ss' % self.entity_type, str(self.id)
+            self.author.get_storage_dir('repo'), '%ss' % self.entity_type, str(self.id)
         )
 
     def nice_version(self, commit):

--- a/weblab/experiments/models.py
+++ b/weblab/experiments/models.py
@@ -181,6 +181,10 @@ class ExperimentVersion(UserCreatedModelMixin, models.Model):
     def abs_path(self):
         return Path(settings.EXPERIMENT_BASE, str(self.id))
 
+    def mkdir(self):
+        """Create the folder for this version's results (and parents if needed)."""
+        self.abs_path.mkdir(exist_ok=True, parents=True)
+
     @property
     def archive_path(self):
         return self.abs_path / 'results.omex'

--- a/weblab/experiments/processing.py
+++ b/weblab/experiments/processing.py
@@ -198,7 +198,7 @@ def process_callback(data, files):
                        '%s (backend returned no archive)' % exp.return_text)
             return {'error': 'no archive found'}
 
-        exp.abs_path.mkdir(exist_ok=True, parents=True)
+        exp.mkdir()
         with exp.archive_path.open('wb+') as dest:
             for chunk in files['experiment'].chunks():
                 dest.write(chunk)

--- a/weblab/experiments/tests/test_models.py
+++ b/weblab/experiments/tests/test_models.py
@@ -176,7 +176,7 @@ class TestExperimentVersion:
 
     def test_files(self, archive_file_path):
         version = recipes.experiment_version.make()
-        version.abs_path.mkdir()
+        version.mkdir()
         shutil.copy(archive_file_path, str(version.archive_path))
 
         assert len(version.files) == 4
@@ -191,7 +191,7 @@ class TestExperimentVersion:
 
     def test_open_file(self, archive_file_path):
         version = recipes.experiment_version.make()
-        version.abs_path.mkdir()
+        version.mkdir()
         shutil.copy(archive_file_path, str(version.archive_path))
 
         assert version.open_file('stdout.txt').readline() == b'line of output\n'

--- a/weblab/experiments/tests/test_views.py
+++ b/weblab/experiments/tests/test_views.py
@@ -1128,7 +1128,6 @@ class TestExperimentVersionJsonView:
         version.author.full_name = 'test user'
         version.author.save()
         version.status = 'SUCCESS'
-        # version.mkdir()
 
         response = client.get(
             ('/experiments/%d/versions/%d/files.json' % (version.experiment.pk, version.pk))

--- a/weblab/experiments/tests/test_views.py
+++ b/weblab/experiments/tests/test_views.py
@@ -1078,7 +1078,7 @@ class TestExperimentComparisonJsonView:
     def test_file_json(self, client, archive_file_path, helpers, experiment_version):
         experiment_version.author.full_name = 'test user'
         experiment_version.author.save()
-        experiment_version.abs_path.mkdir()
+        experiment_version.mkdir()
         shutil.copyfile(archive_file_path, str(experiment_version.archive_path))
         exp = experiment_version.experiment
         exp.model.set_version_visibility('latest', 'public')
@@ -1093,7 +1093,7 @@ class TestExperimentComparisonJsonView:
             experiment__protocol=protocol,
             experiment__protocol_version=protocol_commit.hexsha,
         )
-        version2.abs_path.mkdir()
+        version2.mkdir()
         shutil.copyfile(archive_file_path, str(version2.archive_path))
 
         response = client.get(
@@ -1128,7 +1128,7 @@ class TestExperimentVersionJsonView:
         version.author.full_name = 'test user'
         version.author.save()
         version.status = 'SUCCESS'
-        version.abs_path.mkdir()
+        # version.mkdir()
 
         response = client.get(
             ('/experiments/%d/versions/%d/files.json' % (version.experiment.pk, version.pk))
@@ -1158,7 +1158,7 @@ class TestExperimentVersionJsonView:
         version = experiment_version
         version.author.full_name = 'test user'
         version.author.save()
-        version.abs_path.mkdir()
+        version.mkdir()
         shutil.copyfile(archive_file_path, str(version.archive_path))
 
         response = client.get(
@@ -1181,7 +1181,7 @@ class TestExperimentVersionJsonView:
 @pytest.mark.django_db
 class TestExperimentArchiveView:
     def test_download_archive(self, client, experiment_version, archive_file_path):
-        experiment_version.abs_path.mkdir(exist_ok=True)
+        experiment_version.mkdir()
         shutil.copyfile(archive_file_path, str(experiment_version.archive_path))
         experiment_version.experiment.model.name = 'my_model'
         experiment_version.experiment.model.save()
@@ -1211,7 +1211,7 @@ class TestExperimentArchiveView:
 @pytest.mark.django_db
 class TestExperimentFileDownloadView:
     def test_download_file(self, client, archive_file_path, experiment_version):
-        experiment_version.abs_path.mkdir(exist_ok=True)
+        experiment_version.mkdir()
         shutil.copyfile(archive_file_path, str(experiment_version.archive_path))
 
         response = client.get(
@@ -1226,7 +1226,7 @@ class TestExperimentFileDownloadView:
         assert response['Content-Type'] == 'text/plain'
 
     def test_handles_odd_characters(self, client, archive_file_path, experiment_version):
-        experiment_version.abs_path.mkdir(exist_ok=True)
+        experiment_version.mkdir()
         shutil.copyfile(archive_file_path, str(experiment_version.archive_path))
         filename = 'oxmeta:membrane%3Avoltage - space.csv'
 
@@ -1243,7 +1243,7 @@ class TestExperimentFileDownloadView:
         assert response['Content-Type'] == 'text/csv'
 
     def test_disallows_non_local_files(self, client, archive_file_path, experiment_version):
-        experiment_version.abs_path.mkdir(exist_ok=True)
+        experiment_version.mkdir()
         shutil.copyfile(archive_file_path, str(experiment_version.archive_path))
 
         for filename in ['/etc/passwd', '../../../pytest.ini']:
@@ -1282,7 +1282,7 @@ class TestEnforcesExperimentVersionVisibility:
             experiment__protocol_version=protocol_version.hexsha,
         )
 
-        os.mkdir(str(experiment_version.abs_path))
+        experiment_version.mkdir()
         shutil.copyfile(archive_file_path, str(experiment_version.archive_path))
 
         exp_url = url % (experiment_version.experiment.pk, experiment_version.pk)


### PR DESCRIPTION
We spotted that test datasets weren't being cleaned up after the tests. This is due to the way pytest (and Django) handle database transactions. Each test is run in its own transaction which is rolled back at the end of the test so the DB is clean ready for the next test. But transaction rollback doesn't fire Django pre_delete signals. So WebLab never knew to delete repositories, dataset folders, etc. This issue was compounded by test datasets being created in the git clone, not a tmpdir, because we didn't realise that autouse fixtures were managing this.

So here we have a belt & braces fix. As well as creating an autouse fixture for the dataset storage location, the user fixtures always clean up after themselves for per-user disk storage. And the autouse fixtures have been tidied up a bit for consistency.