### PR TITLE
Added new tasks form for running and queued experiments

### DIFF
--- a/weblab/experiments/tests/test_views.py
+++ b/weblab/experiments/tests/test_views.py
@@ -978,6 +978,7 @@ class TestExperimentTasks:
         running_exp = recipes.running_experiment.make(experiment_version=experiment_version)
         assert RunningExperiment.objects.count() == 1
         response = client.post('/experiments/tasks', {'chkBoxes[]': [running_exp.experiment_version.id]})
+        assert RunningExperiment.objects.count() == 1
         assert response.status_code == 404
 
 @pytest.mark.django_db

--- a/weblab/experiments/tests/test_views.py
+++ b/weblab/experiments/tests/test_views.py
@@ -21,7 +21,6 @@ from experiments.models import (
     PlannedExperiment,
     RunningExperiment,
 )
-from weblab.conftest import Helpers
 
 
 def generate_response(template='%s succ celery-task-id'):
@@ -902,7 +901,7 @@ class TestExperimentVersionView:
 class TestExperimentTasks:
 
     @pytest.mark.usefixtures('other_user')
-    def test_load_page_other_user(self,  client):
+    def test_load_page_other_user(self, client):
         response = client.get('/experiments/tasks')
         assert response.status_code == 302
 
@@ -915,12 +914,12 @@ class TestExperimentTasks:
     def test_get_queryset_other_user(self, other_user, client, experiment_version):
         experiment_version.author = other_user
         experiment_version.save()
-        running_exp = recipes.running_experiment.make(experiment_version=experiment_version)
+        recipes.running_experiment.make(experiment_version=experiment_version)
         assert RunningExperiment.objects.count() == 1
         response = client.get('/experiments/tasks')
         assert len(response.context['runningexperiment_list']) == 0
 
-    def test_get_queryset(self, logged_in_user, client,  helpers):
+    def test_get_queryset(self, logged_in_user, client, helpers):
         # Create three experiment versions 2 running and 1 completed
         model_1 = recipes.model.make(author=logged_in_user)
         model_1_version = helpers.add_version(model_1, visibility='public')
@@ -930,7 +929,7 @@ class TestExperimentTasks:
         protocol_2 = recipes.protocol.make(author=logged_in_user)
         protocol_2_version = helpers.add_version(protocol_2, visibility='public')
 
-        exp_version_1 = recipes.experiment_version.make(
+        recipes.experiment_version.make(
             status=ExperimentVersion.STATUS_SUCCESS,
             experiment__model=model_1,
             experiment__model_version=model_1_version.hexsha,
@@ -983,6 +982,7 @@ class TestExperimentTasks:
         response = client.post('/experiments/tasks', {'chkBoxes[]': [running_exp.experiment_version.id]})
         assert RunningExperiment.objects.count() == 1
         assert response.status_code == 404
+
 
 @pytest.mark.django_db
 class TestExperimentDeletion:

--- a/weblab/experiments/tests/test_views.py
+++ b/weblab/experiments/tests/test_views.py
@@ -900,7 +900,6 @@ class TestExperimentVersionView:
 @pytest.mark.django_db
 class TestExperimentTasks:
 
-    @pytest.mark.usefixtures('other_user')
     def test_load_page_other_user(self, client):
         response = client.get('/experiments/tasks')
         assert response.status_code == 302
@@ -939,7 +938,7 @@ class TestExperimentTasks:
         )
 
         exp_version_2 = recipes.experiment_version.make(
-            status=ExperimentVersion.STATUS_RUNNING,
+            status=ExperimentVersion.STATUS_QUEUED,
             experiment__model=model_1,
             experiment__model_version=model_1_version.hexsha,
             experiment__protocol=protocol_1,
@@ -963,13 +962,11 @@ class TestExperimentTasks:
 
         # Return only running experiment versions
         response = client.get('/experiments/tasks')
-        assert len(response.context['runningexperiment_list']) == 2
         assert set(response.context['runningexperiment_list']) == {running_exp_version2, running_exp_version3}
 
         # Cancel one of the running versions check the other one is still present
         client.post('/experiments/tasks', {'chkBoxes[]': [running_exp_version2.experiment_version.id]})
         response = client.get('/experiments/tasks')
-        assert len(response.context['runningexperiment_list']) == 1
         assert set(response.context['runningexperiment_list']) == {running_exp_version3}
         assert RunningExperiment.objects.count() == 1
 

--- a/weblab/experiments/tests/test_views.py
+++ b/weblab/experiments/tests/test_views.py
@@ -893,6 +893,21 @@ class TestExperimentVersionView:
 
 
 @pytest.mark.django_db
+class TestExperimentTasks:
+    def test_get_queryset(self, logged_in_user, client, queued_experiment):
+        response = client.get('/experiments/tasks')
+        assert response.status_code == 200
+
+    # def test_owner_can_delete_experiment(
+    #     self, logged_in_user, client, queued_experiment
+    # ):
+    #     assert queued_experiment.pk == 1
+    #     assert Experiment.objects.filter(pk=queued_experiment.pk).exists()
+    #     response = client.post('/experiments/task', {'chkBoxes[]': queued_experiment.pk})
+    #     assert Experiment.objects.filter(pk=queued_experiment.pk).exists()
+
+
+@pytest.mark.django_db
 class TestExperimentDeletion:
     def test_owner_can_delete_experiment(
         self, logged_in_user, client, experiment_with_result

--- a/weblab/experiments/tests/test_views.py
+++ b/weblab/experiments/tests/test_views.py
@@ -15,7 +15,10 @@ from django.test import Client
 from django.utils.dateparse import parse_datetime
 
 from core import recipes
-from experiments.models import Experiment, ExperimentVersion, PlannedExperiment
+from experiments.models import Experiment, ExperimentVersion, PlannedExperiment, RunningExperiment
+
+from weblab.conftest import Helpers
+
 
 
 def generate_response(template='%s succ celery-task-id'):
@@ -894,9 +897,88 @@ class TestExperimentVersionView:
 
 @pytest.mark.django_db
 class TestExperimentTasks:
-    def test_get_queryset(self, logged_in_user, client):
+
+    @pytest.mark.usefixtures('other_user')
+    def test_load_page_other_user(self,  client):
+        response = client.get('/experiments/tasks')
+        assert response.status_code == 302
+
+    @pytest.mark.usefixtures('logged_in_user')
+    def test_load_page_logged_in_user(self, client):
         response = client.get('/experiments/tasks')
         assert response.status_code == 200
+
+    @pytest.mark.usefixtures('logged_in_user')
+    def test_get_queryset_other_user(self, other_user, client, experiment_version):
+        experiment_version.author = other_user
+        experiment_version.save()
+        running_exp = recipes.running_experiment.make(experiment_version=experiment_version)
+        assert RunningExperiment.objects.count() == 1
+        response = client.get('/experiments/tasks')
+        assert len(response.context['runningexperiment_list']) == 0
+
+    def test_get_queryset(self, logged_in_user, client,  helpers):
+        # Create three experiment versions 2 running and 1 completed
+        model_1 = recipes.model.make(author=logged_in_user)
+        model_1_version = helpers.add_version(model_1, visibility='public')
+        protocol_1 = recipes.protocol.make(author=logged_in_user)
+        protocol_1_version = helpers.add_version(protocol_1, visibility='public')
+        protocol_1_version2 = helpers.add_version(protocol_1, visibility='public')
+        protocol_2 = recipes.protocol.make(author=logged_in_user)
+        protocol_2_version = helpers.add_version(protocol_2, visibility='public')
+
+        exp_version_1 = recipes.experiment_version.make(
+            status=ExperimentVersion.STATUS_SUCCESS,
+            experiment__model=model_1,
+            experiment__model_version=model_1_version.hexsha,
+            experiment__protocol=protocol_1,
+            experiment__protocol_version=protocol_1_version.hexsha,
+            author=logged_in_user,
+        )
+
+        exp_version_2 = recipes.experiment_version.make(
+            status=ExperimentVersion.STATUS_RUNNING,
+            experiment__model=model_1,
+            experiment__model_version=model_1_version.hexsha,
+            experiment__protocol=protocol_1,
+            experiment__protocol_version=protocol_1_version2.hexsha,
+            author=logged_in_user,
+        )
+        running_exp_version2 = recipes.running_experiment.make(experiment_version=exp_version_2)
+
+        exp_version_3 = recipes.experiment_version.make(
+            status=ExperimentVersion.STATUS_RUNNING,
+            experiment__model=model_1,
+            experiment__model_version=model_1_version.hexsha,
+            experiment__protocol=protocol_2,
+            experiment__protocol_version=protocol_2_version.hexsha,
+            author=logged_in_user,
+        )
+        running_exp_version3 = recipes.running_experiment.make(experiment_version=exp_version_3)
+
+        assert ExperimentVersion.objects.count() == 3
+        assert RunningExperiment.objects.count() == 2
+
+        # Return only running experiment versions
+        response = client.get('/experiments/tasks')
+        assert len(response.context['runningexperiment_list']) == 2
+        assert set(response.context['runningexperiment_list']) == {running_exp_version2, running_exp_version3}
+
+        # Cancel one of the running versions check the other one is still present
+        client.post('/experiments/tasks', {'chkBoxes[]': [running_exp_version2.experiment_version.id]})
+        response = client.get('/experiments/tasks')
+        assert len(response.context['runningexperiment_list']) == 1
+        assert set(response.context['runningexperiment_list']) == {running_exp_version3}
+        assert RunningExperiment.objects.count() == 1
+
+    @pytest.mark.usefixtures('logged_in_user')
+    def test_returns_404_incorrect_owner(self, other_user, client, experiment_version):
+        experiment_version.author = other_user
+        experiment_version.save()
+        running_exp = recipes.running_experiment.make(experiment_version=experiment_version)
+        assert RunningExperiment.objects.count() == 1
+        response = client.post('/experiments/tasks', {'chkBoxes[]': [running_exp.experiment_version.id]})
+        assert response.status_code == 404
 
 @pytest.mark.django_db
 class TestExperimentDeletion:

--- a/weblab/experiments/tests/test_views.py
+++ b/weblab/experiments/tests/test_views.py
@@ -15,10 +15,13 @@ from django.test import Client
 from django.utils.dateparse import parse_datetime
 
 from core import recipes
-from experiments.models import Experiment, ExperimentVersion, PlannedExperiment, RunningExperiment
-
+from experiments.models import (
+    Experiment,
+    ExperimentVersion,
+    PlannedExperiment,
+    RunningExperiment,
+)
 from weblab.conftest import Helpers
-
 
 
 def generate_response(template='%s succ celery-task-id'):

--- a/weblab/experiments/tests/test_views.py
+++ b/weblab/experiments/tests/test_views.py
@@ -894,18 +894,9 @@ class TestExperimentVersionView:
 
 @pytest.mark.django_db
 class TestExperimentTasks:
-    def test_get_queryset(self, logged_in_user, client, queued_experiment):
+    def test_get_queryset(self, logged_in_user, client):
         response = client.get('/experiments/tasks')
         assert response.status_code == 200
-
-    # def test_owner_can_delete_experiment(
-    #     self, logged_in_user, client, queued_experiment
-    # ):
-    #     assert queued_experiment.pk == 1
-    #     assert Experiment.objects.filter(pk=queued_experiment.pk).exists()
-    #     response = client.post('/experiments/task', {'chkBoxes[]': queued_experiment.pk})
-    #     assert Experiment.objects.filter(pk=queued_experiment.pk).exists()
-
 
 @pytest.mark.django_db
 class TestExperimentDeletion:

--- a/weblab/experiments/urls.py
+++ b/weblab/experiments/urls.py
@@ -105,7 +105,4 @@ urlpatterns = [
         views.ExperimentComparisonJsonView.as_view(),
         name='compare_json',
     ),
-
-
-
 ]

--- a/weblab/experiments/urls.py
+++ b/weblab/experiments/urls.py
@@ -23,6 +23,12 @@ urlpatterns = [
     ),
 
     url(
+        r'^tasks$',
+        views.ExperimentTasks.as_view(),
+        name='tasks',
+    ),
+
+    url(
         r'^new$',
         views.NewExperimentView.as_view(),
         name='new',
@@ -99,4 +105,7 @@ urlpatterns = [
         views.ExperimentComparisonJsonView.as_view(),
         name='compare_json',
     ),
+
+
+
 ]

--- a/weblab/experiments/views.py
+++ b/weblab/experiments/views.py
@@ -64,7 +64,7 @@ class ExperimentTasks(LoginRequiredMixin, ListView):
 
     def get_queryset(self):
         return RunningExperiment.objects.filter(
-            Q(experiment_version__author=self.request.user)
+            experiment_version__author=self.request.user
         ).order_by(
             'experiment_version__created_at',
         ).select_related('experiment_version', 'experiment_version__experiment')

--- a/weblab/experiments/views.py
+++ b/weblab/experiments/views.py
@@ -34,6 +34,7 @@ from .forms import ExperimentSimulateCallbackForm
 from .models import Experiment, ExperimentVersion, RunningExperiment, PlannedExperiment
 from .processing import process_callback, submit_experiment
 
+
 logger = logging.getLogger(__name__)
 
 

--- a/weblab/experiments/views.py
+++ b/weblab/experiments/views.py
@@ -15,7 +15,7 @@ from django.db.models import (
     Subquery,
 )
 from django.db.models.functions import Coalesce
-from django.http import Http404, HttpResponse, JsonResponse, HttpResponseRedirect
+from django.http import Http404, HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, redirect
 from django.utils.decorators import method_decorator
 from django.utils.text import get_valid_filename
@@ -32,7 +32,6 @@ from entities.models import ModelEntity, ProtocolEntity
 from repocache.entities import get_moderated_entity_ids, get_public_entity_ids
 from repocache.models import CachedEntityVersion
 
-from weblab import experiments
 from .forms import ExperimentSimulateCallbackForm
 from .models import Experiment, ExperimentVersion, PlannedExperiment
 from .processing import process_callback, submit_experiment

--- a/weblab/experiments/views.py
+++ b/weblab/experiments/views.py
@@ -417,12 +417,6 @@ class ExperimentVersionDeleteView(UserPassesTestMixin, DeleteView):
         return reverse('experiments:versions', args=[self.get_object().experiment.id])
 
 
-class ExperimentVersionMultipleDeleteView(TemplateView):
-    template_name = 'entities/compare.html'
-
-    def get_context_data(self, **kwargs):
-        versions = self.kwargs['versions'].strip('/').split('/')
-
 
 class ExperimentComparisonView(TemplateView):
     """

--- a/weblab/experiments/views.py
+++ b/weblab/experiments/views.py
@@ -5,7 +5,11 @@ import urllib.parse
 
 from django.contrib import messages
 from django.contrib.admin.views.decorators import staff_member_required
-from django.contrib.auth.mixins import LoginRequiredMixin, PermissionRequiredMixin, UserPassesTestMixin
+from django.contrib.auth.mixins import (
+    LoginRequiredMixin,
+    PermissionRequiredMixin,
+    UserPassesTestMixin,
+)
 from django.core.urlresolvers import reverse
 from django.db.models import (
     F,
@@ -31,7 +35,12 @@ from repocache.entities import get_moderated_entity_ids, get_public_entity_ids
 from repocache.models import CachedEntityVersion
 
 from .forms import ExperimentSimulateCallbackForm
-from .models import Experiment, ExperimentVersion, RunningExperiment, PlannedExperiment
+from .models import (
+    Experiment,
+    ExperimentVersion,
+    PlannedExperiment,
+    RunningExperiment,
+)
 from .processing import process_callback, submit_experiment
 
 

--- a/weblab/experiments/views.py
+++ b/weblab/experiments/views.py
@@ -72,7 +72,6 @@ class ExperimentMatrixJsonView(View):
     """
     Serve up JSON for experiment matrix
     """
-
     @classmethod
     def entity_json(cls, entity, version, *, extend_name, visibility, author, friendly_version=''):
         if extend_name:
@@ -443,7 +442,6 @@ class ExperimentComparisonJsonView(View):
     """
     Serve up JSON view of multiple experiment versions for comparison
     """
-
     def _file_json(self, version, archive_file):
         """
         JSON for a single file in the experiment archive

--- a/weblab/experiments/views.py
+++ b/weblab/experiments/views.py
@@ -5,8 +5,7 @@ import urllib.parse
 
 from django.contrib import messages
 from django.contrib.admin.views.decorators import staff_member_required
-from django.contrib.auth.mixins import LoginRequiredMixin, PermissionRequiredMixin, UserPassesTestMixin, \
-    LoginRequiredMixin
+from django.contrib.auth.mixins import LoginRequiredMixin, PermissionRequiredMixin, UserPassesTestMixin
 from django.core.urlresolvers import reverse
 from django.db.models import (
     F,
@@ -16,15 +15,14 @@ from django.db.models import (
 )
 from django.db.models.functions import Coalesce
 from django.http import Http404, HttpResponse, JsonResponse
-from django.shortcuts import get_object_or_404, redirect
+from django.shortcuts import get_object_or_404
 from django.utils.decorators import method_decorator
 from django.utils.text import get_valid_filename
 from django.views import View
 from django.views.decorators.csrf import csrf_exempt
-from django.views.generic import TemplateView
+from django.views.generic import ListView, TemplateView
 from django.views.generic.detail import DetailView, SingleObjectMixin
 from django.views.generic.edit import DeleteView, FormMixin
-from django.views.generic.list import ListView
 from guardian.shortcuts import get_objects_for_user
 
 from core.visibility import VisibilityMixin, visible_entity_ids
@@ -35,7 +33,6 @@ from repocache.models import CachedEntityVersion
 from .forms import ExperimentSimulateCallbackForm
 from .models import Experiment, ExperimentVersion, RunningExperiment, PlannedExperiment
 from .processing import process_callback, submit_experiment
-
 
 logger = logging.getLogger(__name__)
 
@@ -416,7 +413,6 @@ class ExperimentVersionDeleteView(UserPassesTestMixin, DeleteView):
 
     def get_success_url(self, *args, **kwargs):
         return reverse('experiments:versions', args=[self.get_object().experiment.id])
-
 
 
 class ExperimentComparisonView(TemplateView):

--- a/weblab/static/js/experiment_tasks.js
+++ b/weblab/static/js/experiment_tasks.js
@@ -1,0 +1,28 @@
+
+var ExperimentVersionList = function() {};
+
+ExperimentVersionList.prototype = {
+  init: function() {
+
+    $("#cancelRunningExperimentsAll").click (function () {
+      $(".taskCancelCheckBox").prop('checked', true);
+    });
+    $("#cancelRunningExperimentsNone").click (function () {
+      $(".taskCancelCheckBox").prop('checked', false);
+    });
+
+    $("#taskRefreshPage").click (function () {
+      window.location.reload()
+    });
+
+
+  }	
+};
+
+$(document).ready(function() {
+
+  if ($("#experimentversionlist").length > 0) {
+    var page = new ExperimentVersionList();
+    page.init();
+  }
+});

--- a/weblab/static/js/main.js
+++ b/weblab/static/js/main.js
@@ -10,6 +10,7 @@ var experiment = require('./experiment.js');
 var notifications = require('./lib/notifications.js');
 require('./compare.js');
 require('./entity_version_list.js');
+require('./experiment_tasks');
 require('./run_experiment.js');
 require('django-formset');
 

--- a/weblab/static/js/main.js
+++ b/weblab/static/js/main.js
@@ -10,7 +10,7 @@ var experiment = require('./experiment.js');
 var notifications = require('./lib/notifications.js');
 require('./compare.js');
 require('./entity_version_list.js');
-require('./experiment_tasks');
+require('./experiment_tasks.js');
 require('./run_experiment.js');
 require('django-formset');
 

--- a/weblab/static/sass/style.scss
+++ b/weblab/static/sass/style.scss
@@ -97,7 +97,7 @@ button,
     }
 
     a, a:hover, a:active {
-        padding: 10px 0;  /* Reduce padding so as to fit number of lines in sub menu */
+        padding: 7px 0;  /* Reduce padding so as to fit number of lines in sub menu */
         text-decoration: none; /* Removes the default hyperlink styling. */
         display: block;
         border: none;

--- a/weblab/static/sass/style.scss
+++ b/weblab/static/sass/style.scss
@@ -97,7 +97,7 @@ button,
     }
 
     a, a:hover, a:active {
-        padding: 10px 0;  /* Reduce padding to fit number of icons in sub menu */
+        padding: 10px 0;  /* Reduce padding so as to fit number of lines in sub menu */
         text-decoration: none; /* Removes the default hyperlink styling. */
         display: block;
         border: none;

--- a/weblab/static/sass/style.scss
+++ b/weblab/static/sass/style.scss
@@ -97,7 +97,7 @@ button,
     }
 
     a, a:hover, a:active {
-        padding: 18px 0;  /* Adds a padding on the top and bottom so the text appears centered vertically */
+        padding: 10px 0;  /* Reduce padding to fit number of icons in sub menu */
         text-decoration: none; /* Removes the default hyperlink styling. */
         display: block;
         border: none;
@@ -743,3 +743,29 @@ li.entityviz-PRIVATE
   vertical-align: middle;
   line-height: 24px;
 }
+
+#taskHeader {
+  display: flex;
+  align-items: baseline;
+}
+
+#taskRefreshPage {
+  padding-left: 10px;
+}
+
+#taskList {
+  list-style: none;
+}
+
+.taskCancelCheckBox {
+  float: left;
+}
+
+#taskDetailBox {
+  overflow: hidden;
+}
+
+#taskVersionDetailBox {
+  display: flex;
+}
+

--- a/weblab/templates/experiments/experiment_tasks.html
+++ b/weblab/templates/experiments/experiment_tasks.html
@@ -32,35 +32,18 @@
                 <p class="failed">You have no queued or running tasks.</p>
             {% endif %}
 
-            {% for experiment in object_list|dictsort:"name" %}
-                {{ experiment.name }}
-                <div class="suppl">
-                    <small>Experiment created
-                        <time>{{ experiment.created_at }}</time>
-                        by <em>{{ experiment.author.full_name }}</em>.
-                    </small>
-                </div>
-                <ul id="taskList">
-                    {% for version in experiment.versions.all|dictsortreversed:"created_at" %}
-                        <li>
-                            <div id="taskDisplay">
-                                <input class="taskCancelCheckBox" type="checkbox" name="chkBoxes[]"
-                                       value="{{ version.id }}">
-                                <div class="experiment-{{ version.status }}" id="taskDetailBox">
-                                    Version: {{ version.name }} by
-                                    <em>{{ version.author.full_name }}</em>
-                                    <div class="suppl" id="taskVersionDetailBox" style="padding-bottom: 0px">
-                                        <small>Created&nbsp;</small>
-                                        <time>{{ version.created_at }}&nbsp;</time>
-                                        {% with version.files|length as numfiles %}
-                                            <small>containing&nbsp;</small> {{ numfiles }} file{{ numfiles|pluralize }}
-                                        {% endwith %}
-                                    </div>
-                                </div>
-                            </div>
-                        </li>
+            {% for running_experiment in object_list %}
 
-                    {% endfor %}
+                <ul id="taskList">
+                    <li>
+                        <div id="taskDisplay">
+                            <input class="taskCancelCheckBox" type="checkbox" name="chkBoxes[]"
+                                   value="{{ running_experiment.experiment_version.id }}">
+                            <div class="experiment-{{ running_experiment.experiment_version.status }}" id="taskDetailBox">
+                               {{ running_experiment.experiment_version.experiment.name }} Version: {{ running_experiment.experiment_version.name }}
+                            </div>
+                        </div>
+                    </li>
                 </ul>
             {% endfor %}
             </c:forEach>

--- a/weblab/templates/experiments/experiment_tasks.html
+++ b/weblab/templates/experiments/experiment_tasks.html
@@ -35,7 +35,7 @@
             {% for experiment in object_list|dictsort:"name" %}
                 {{ experiment.name }}
                 <div class="suppl">
-                    <small>Experiment version created
+                    <small>Experiment created
                         <time>{{ experiment.created_at }}</time>
                         by <em>{{ experiment.author.full_name }}</em>.
                     </small>

--- a/weblab/templates/experiments/experiment_tasks.html
+++ b/weblab/templates/experiments/experiment_tasks.html
@@ -1,0 +1,76 @@
+{% extends "base.html" %}
+{% load experiments %}
+{% load staticfiles %}
+
+{% block title %}Running Experiments{% endblock title %}
+
+{% block content %}
+
+    <div id="taskHeader">
+        <h2>List of active tasks</h2>
+        <a id="taskRefreshPage"><img src="{% static 'img/refresh.png' %}" alt="Refresh tasks"
+                                     title="Refresh tasks"/></a>
+    </div>
+
+    {% if  object_list %}
+        <p>
+            [<small><a id="cancelRunningExperimentsAll">select all</a></small>]
+            [<small><a id="cancelRunningExperimentsNone">select none</a></small>]
+        </p>
+    {% endif %}
+
+    <form action="" method="post">
+        {% csrf_token %}
+
+        {% if  object_list %}
+            <p>
+                <button type="submit">Cancel selected experiments</button>
+            </p>
+        {% endif %}
+        <div id="experimentversionlist">
+            {% if not object_list %}
+                <p class="failed">You have no queued or running tasks.</p>
+            {% endif %}
+
+            {% for experiment in object_list|dictsort:"name" %}
+                {{ experiment.name }}
+                <div class="suppl">
+                    <small>Experiment version created
+                        <time>{{ experiment.created_at }}</time>
+                        by <em>{{ experiment.author.full_name }}</em>.
+                    </small>
+                </div>
+                <ul id="taskList">
+                    {% for version in experiment.versions.all|dictsortreversed:"created_at" %}
+                        <li>
+                            <div id="taskDisplay">
+                                <input class="taskCancelCheckBox" type="checkbox" name="chkBoxes[]"
+                                       value="{{ version.id }}">
+                                <div class="experiment-{{ version.status }}" id="taskDetailBox">
+                                    Version: {{ version.name }} by
+                                    <em>{{ version.author.full_name }}</em>
+                                    <div class="suppl" id="taskVersionDetailBox" style="padding-bottom: 0px">
+                                        <small>Created&nbsp;</small>
+                                        <time>{{ version.created_at }}&nbsp;</time>
+                                        {% with version.files|length as numfiles %}
+                                            <small>containing&nbsp;</small> {{ numfiles }} file{{ numfiles|pluralize }}
+                                        {% endwith %}
+                                    </div>
+                                </div>
+                            </div>
+                        </li>
+
+                    {% endfor %}
+                </ul>
+            {% endfor %}
+            </c:forEach>
+        </div>
+        {% if object_list %}
+            <p id='expversioncolorlegend'>
+                Key:
+                <span class="experiment-QUEUED">queued</span>
+                <span class="experiment-RUNNING">running</span>
+            </p>
+        {% endif %}
+    </form>
+{% endblock content %}

--- a/weblab/templates/experiments/experiment_tasks.html
+++ b/weblab/templates/experiments/experiment_tasks.html
@@ -2,7 +2,7 @@
 {% load experiments %}
 {% load staticfiles %}
 
-{% block title %}Running Experiments{% endblock title %}
+{% block title %}Tasks - {% endblock title %}
 
 {% block content %}
 

--- a/weblab/templates/experiments/experiment_tasks.html
+++ b/weblab/templates/experiments/experiment_tasks.html
@@ -29,7 +29,7 @@
         {% endif %}
         <div id="experimentversionlist">
             {% if not object_list %}
-                <p class="failed">You have no queued or running tasks.</p>
+                <p class="failed">You have no running tasks.</p>
             {% endif %}
 
             {% for running_experiment in object_list %}

--- a/weblab/templates/includes/navbar.html
+++ b/weblab/templates/includes/navbar.html
@@ -16,6 +16,7 @@
           <a>{{ user.full_name }}</a>
           <ul>
             <li><a href="{% url 'entities:list' 'model' %}">My Files</a></li>
+            <li><a href="{% url 'experiments:tasks' %}">Tasks</a></li>
             <li><a href="{% url 'accounts:myaccount' %}">Account</a></li>
 
             {% if user.is_superuser %}


### PR DESCRIPTION
Fixes #207

I have created an initial write of the delete running experiments enhancement. I haven't finished the unit tests (because I need another day and also wanted to make sure I was on the right track first). I have used HTML forms rather than Django forms (forms.py) because it seemed easier to style these. I am also not sure about functionality for "admins" should they get a list of all running experiments. Currently I am only filtering on author. I haven't implemented a delete confirmation prompt or any send email functionality - can do if these are required.   