### PR TITLE
Don't kill finishing back-end tasks!

### DIFF
--- a/weblab/experiments/processing.py
+++ b/weblab/experiments/processing.py
@@ -188,6 +188,9 @@ def process_callback(data, files):
     exp.save()
 
     if exp.is_finished or exp.status == ExperimentVersion.STATUS_INAPPLICABLE:
+        # We unset the task_id to ensure the delete() below doesn't send a message to the back-end cancelling
+        # the task, causing it to be killed while still sending us its 'finished' message!
+        run.task_id = ''
         run.delete()
 
     if exp.is_finished:


### PR DESCRIPTION
I figured out the root cause of the weird `SoftTimeLimitExceeded` errors we were getting when posting results back to the front-end. When the front-end deleted the running experiment record, this sent a terminate message to the back-end, and because it hadn't yet received the response to its POST, it got killed. This change stops the front-end sending that kill message.

Fixes #146 properly.