### PR TITLE
Show expt with latest version, not latest expt

### DIFF
--- a/weblab/entities/tests/test_views.py
+++ b/weblab/entities/tests/test_views.py
@@ -2,6 +2,7 @@ import io
 import json
 import uuid
 import zipfile
+from datetime import timedelta
 from io import BytesIO
 from subprocess import SubprocessError
 from unittest.mock import patch
@@ -445,19 +446,37 @@ class TestGetProtocolInterfacesJsonView:
 
 @pytest.mark.django_db
 class TestModelEntityCompareExperimentsView:
-    def test_shows_related_experiments(self, client, experiment_version):
+    def test_shows_related_experiments(self, client, helpers, experiment_version):
         exp = experiment_version.experiment
         sha = exp.model.repo.latest_commit.sha
         recipes.experiment_version.make()  # another experiment which should not be included
         exp.model.set_version_visibility('latest', 'public')
         exp.protocol.set_version_visibility('latest', 'public')
 
+        # Add an experiment with a newer version of the protocol but that was created earlier
+        exp2 = recipes.experiment_version.make(
+            experiment__protocol=exp.protocol,
+            experiment__protocol_version=helpers.add_version(exp.protocol, visibility='public').sha,
+            experiment__model=exp.model,
+            experiment__model_version=sha,
+        ).experiment
+        exp2.created_at = exp.created_at - timedelta(seconds=10)
+        exp2.save()
+
+        # Add an experiment with a newer version of the protocol and that was created later
+        exp3 = recipes.experiment_version.make(
+            experiment__protocol=exp.protocol,
+            experiment__protocol_version=helpers.add_version(exp.protocol, visibility='public').sha,
+            experiment__model=exp.model,
+            experiment__model_version=sha,
+        ).experiment
+
         response = client.get(
             '/entities/models/%d/versions/%s/compare' % (exp.model.pk, sha)
         )
 
         assert response.status_code == 200
-        assert response.context['comparisons'] == [(exp.protocol, [exp])]
+        assert response.context['comparisons'] == [(exp.protocol, [exp3, exp2, exp])]
 
     def test_applies_visibility(self, client, helpers, experiment_version):
         exp = experiment_version.experiment

--- a/weblab/entities/views.py
+++ b/weblab/entities/views.py
@@ -17,7 +17,13 @@ from django.contrib.auth.mixins import (
 )
 from django.core.exceptions import PermissionDenied
 from django.core.urlresolvers import reverse
-from django.db.models import Count, F, Q
+from django.db.models import (
+    Count,
+    F,
+    OuterRef,
+    Q,
+    Subquery,
+)
 from django.http import (
     Http404,
     HttpResponse,
@@ -41,7 +47,7 @@ from core.filetypes import get_file_type
 from core.visibility import Visibility, VisibilityMixin
 from experiments.models import Experiment, ExperimentVersion, PlannedExperiment
 from repocache.exceptions import RepoCacheMiss
-from repocache.models import CachedProtocolVersion
+from repocache.models import CACHED_VERSION_TYPE_MAP, CachedProtocolVersion
 
 from .forms import (
     EntityChangeVisibilityForm,
@@ -264,14 +270,21 @@ class EntityCompareExperimentsView(EntityTypeMixin, EntityVersionMixin, DetailVi
 
         entity_type = entity.entity_type
         other_type = entity.other_type
+
+        q_other_type_versions = CACHED_VERSION_TYPE_MAP[other_type].objects.filter(
+            entity__entity=OuterRef(other_type),
+            sha=OuterRef(other_type + '_version'),
+        )
+
         experiments = Experiment.objects.filter(**{
             entity_type: entity.pk,
-            ('%s_version' % entity_type): commit.sha,
+            entity_type + '_version': commit.sha,
         }).annotate(
             version_count=Count('versions'),
+            other_version_timestamp=Subquery(q_other_type_versions.values('timestamp')[:1]),
         ).filter(
             version_count__gt=0,
-        ).select_related(other_type).order_by(other_type, '-created_at')
+        ).select_related(other_type).order_by(other_type, '-other_version_timestamp')
 
         experiments = [
             exp for exp in experiments


### PR DESCRIPTION
This fixes the issue with the comparison view found while discussing #230.