### PR TITLE
Changes required to support running tests in windows

### DIFF
--- a/weblab/accounts/models.py
+++ b/weblab/accounts/models.py
@@ -60,15 +60,3 @@ class User(PermissionsMixin, AbstractBaseUser):
         :return: `Path` object
         """
         return self.STORAGE_DIRS[kind] / str(self.id)
-
-    def clean_up_storage(self):
-        """Remove all on-disk storage associated with this user.
-
-        Intended for use by tests, not production code. It works around the problem
-        that DB transaction rollback doesn't call pre_delete signals.
-        """
-        from shutil import rmtree
-        for kind in self.STORAGE_DIRS.keys():
-            storage_dir = self.get_storage_dir(kind)
-            if storage_dir.exists():
-                rmtree(str(storage_dir))

--- a/weblab/conftest.py
+++ b/weblab/conftest.py
@@ -239,7 +239,6 @@ def admin_user():
         password='password',
     )
     yield user
-    user.clean_up_storage()
 
 
 @pytest.fixture
@@ -251,7 +250,6 @@ def user():
         password='password',
     )
     yield user
-    user.clean_up_storage()
 
 
 @pytest.fixture
@@ -263,7 +261,6 @@ def other_user():
         password='password',
     )
     yield user
-    user.clean_up_storage()
 
 
 @pytest.fixture

--- a/weblab/core/combine.py
+++ b/weblab/core/combine.py
@@ -46,6 +46,9 @@ class ManifestWriter:
         :path: Path of target file
         :return: namespaced mime type if identified, empty string otherwise
         """
+        # make csv mapping explicit (in windows tests, defaults to excel)
+        mimetypes.add_type('text/csv', '.csv')
+
         fmt, _ = mimetypes.guess_type(path)
         return MIME_NS + fmt if fmt else ''
 

--- a/weblab/entities/tests/test_models.py
+++ b/weblab/entities/tests/test_models.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 from django.db.utils import IntegrityError
 
@@ -45,7 +47,7 @@ class TestEntity:
 
     def test_repo_abs_path(self, fake_repo_path):
         model = recipes.model.make()
-        path = '%s/%d/models/%d' % (fake_repo_path, model.author.pk, model.pk)
+        path = os.path.join(str(fake_repo_path), str(model.author.pk), 'models', str(model.pk))
 
         assert model.repo._root == path
         assert str(model.repo_abs_path) == path

--- a/weblab/experiments/tests/test_models.py
+++ b/weblab/experiments/tests/test_models.py
@@ -1,3 +1,4 @@
+import os
 import shutil
 from datetime import date
 from pathlib import Path
@@ -132,11 +133,11 @@ class TestExperiment:
 class TestExperimentVersion:
     def test_abs_path(self, fake_experiment_path):
         version = recipes.experiment_version.make(id=2)
-        assert str(version.abs_path) == '%s/2' % fake_experiment_path
+        assert str(version.abs_path) == os.path.join(str(fake_experiment_path), '2')
 
     def test_archive_path(self, fake_experiment_path):
         version = recipes.experiment_version.make(id=2)
-        assert str(version.archive_path) == '%s/2/results.omex' % fake_experiment_path
+        assert str(version.archive_path) == os.path.join(str(fake_experiment_path), '2', 'results.omex')
 
     def test_signature(self):
         running = recipes.running_experiment.make()


### PR DESCRIPTION
The following changes have been added to address failures when running pytests in windows

Note particularly:

1) I attempted to patch the mimetype module and use autouse fixtures but wasn't able to figure out the required syntax so added an explicit mapping in `def identify_mime_type(path)`

2) In windows repo files are marked as readonly. This causes problems when trying to delete the repo. More information is available [here](https://stackoverflow.com/questions/1213706/what-user-do-python-scripts-run-as-in-windows). I have address this by implementing an error handler and changing the file permissions. 

3) I have removed the method `clean_up_storage`. I did check to see if I could see redundant files persisting as a result of doing so. I couldn't but further testing might be required here. 

