### PR TITLE
Change to make test cross-platform

### DIFF
--- a/weblab/entities/tests/test_views.py
+++ b/weblab/entities/tests/test_views.py
@@ -1,5 +1,6 @@
 import io
 import json
+import os
 import uuid
 import zipfile
 from datetime import timedelta
@@ -1967,8 +1968,8 @@ class TestEntityDiffView:
             'https://bives.bio.informatik.uni-rostock.de/',
             json={
                 'files': [
-                    'v1 contents\n',
-                    'v2 contents\n'
+                    'v1 contents' + os.linesep,
+                    'v2 contents' + os.linesep
                 ],
                 'commands': [
                     'compHierarchyJson',


### PR DESCRIPTION
Changed single test in entities\test_views to make cross-platform. 

Note: There are two remaining tests that fail in Windows OS in the same file, These are

- test_unix_diff
- test_can_diff_entities_if_collaborator

The problem appears to be the way that the temp files are opened in Windows. A lock is retained (possibly for the purposes of later deletion). this causes the subprocess to fail when opening them, See [here ](https://stackoverflow.com/questions/15169101/how-to-create-a-temporary-file-that-can-be-read-by-a-subprocess?noredirect=1&lq=1)for a further discussion.  I have attempted the workaround but the subprocess still fails and also we would run the risk of the files not being deleted.