### PR TITLE
Template testing

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -16,8 +16,7 @@ defusedxml==0.5.0         # via python3-openid, social-auth-core
 dj-database-url==0.4.2
 django-braces==1.11.0
 django-guardian==1.4.9
-django==1.11.27
-first==2.0.2              # via pip-tools
+django==1.11.28
 flake8==3.4.1
 gitdb2==2.0.5             # via gitpython
 gitpython==2.1.7

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -28,8 +28,8 @@ pycodestyle==2.5.0        # via flake8
 pyflakes==2.1.1           # via flake8
 pyjwt==1.7.1              # via social-auth-core
 pytest-cov==2.5.1
-pytest-django==3.1.2
-pytest==3.2.0
+pytest-django==3.8.0
+pytest==3.6.0
 python3-openid==3.1.0     # via social-auth-core
 pytz==2018.9              # via django
 requests-oauthlib==1.2.0  # via social-auth-core

--- a/weblab/core/recipes.py
+++ b/weblab/core/recipes.py
@@ -1,19 +1,19 @@
 from model_mommy.recipe import Recipe, foreign_key, seq
 
 
-user = Recipe('accounts.User', institution='UCL')
+user = Recipe('accounts.User', institution='UCL', full_name=seq('test user '))
 
 model = Recipe(
     'ModelEntity',
-    entity_type='model', name=seq('mymodel')
+    entity_type='model', name=seq('my model')
 )
 protocol = Recipe(
     'ProtocolEntity',
-    entity_type='protocol', name=seq('myprotocol')
+    entity_type='protocol', name=seq('my protocol')
 )
 fittingspec = Recipe(
     'FittingSpec',
-    entity_type='fittingspec', name=seq('myspec'),
+    entity_type='fittingspec', name=seq('my spec'),
     protocol=foreign_key(protocol),
 )
 
@@ -46,7 +46,7 @@ running_experiment = Recipe('RunningExperiment', runnable=foreign_key(runnable))
 
 
 dataset = Recipe('Dataset',
-                 name=seq('mydataset'),
+                 name=seq('my dataset'),
                  protocol=foreign_key(protocol))
 
 dataset_file = Recipe('DatasetFile',

--- a/weblab/entities/tests/test_views.py
+++ b/weblab/entities/tests/test_views.py
@@ -431,10 +431,10 @@ class TestGetProtocolInterfacesJsonView:
         assert len(interfaces) == 4
 
         expected = {
-            'myprotocol1': {'required': ['p1r2'], 'optional': ['p1o2']},
-            'myprotocol2': {'required': ['p2r2'], 'optional': ['p2o2']},
-            'myprotocol3': {'required': ['p3r1'], 'optional': ['p3o1']},
-            'myprotocol4': {'required': ['p4r3'], 'optional': ['p4o3']},
+            protocol1.name: {'required': ['p1r2'], 'optional': ['p1o2']},
+            protocol2.name: {'required': ['p2r2'], 'optional': ['p2o2']},
+            protocol3.name: {'required': ['p3r1'], 'optional': ['p3o1']},
+            protocol4.name: {'required': ['p4r3'], 'optional': ['p4o3']},
         }
         for iface in interfaces:
             assert iface['name'] in expected
@@ -1666,7 +1666,7 @@ class TestEntityArchiveView:
         archive = zipfile.ZipFile(BytesIO(response.content))
         assert archive.filelist[0].filename == 'file1.txt'
         assert response['Content-Disposition'] == (
-            'attachment; filename=%s_%s.zip' % (model.name, commit.sha)
+            'attachment; filename=%s_%s.zip' % (model.name.replace(' ', '_'), commit.sha)
         )
 
     def test_returns_404_if_no_commits_yet(self, logged_in_user, client):
@@ -2115,7 +2115,7 @@ class TestEntityRunExperiment:
         assert response.status_code == 200
         assert response.context['object_list'] == [{'id': protocol.pk,
                                                     'entity': protocol,
-                                                    'name': 'myprotocol1',
+                                                    'name': protocol.name,
                                                     'versions': [{'commit': version2, 'tags': ['v1'], 'latest': True},
                                                                  {'commit': version1, 'tags': [], 'latest': False}]},
                                                    ]
@@ -2147,14 +2147,14 @@ class TestEntityRunExperiment:
         assert response.status_code == 200
         assert response.context['object_list'] == [{'id': protocol.pk,
                                                     'entity': protocol,
-                                                    'name': 'myprotocol1',
+                                                    'name': protocol.name,
                                                     'versions': [{'commit': version2, 'tags': ['v1'], 'latest': True},
                                                                  {'commit': version1, 'tags': [], 'latest': False}]},
                                                    ]
         assert response.context['other_object_list'] == [
             {'id': other_protocol.pk,
              'entity': other_protocol,
-             'name': 'myprotocol2',
+             'name': other_protocol.name,
              'versions': [{'commit': other_version2, 'tags': ['v1'], 'latest': True},
                           {'commit': other_version1, 'tags': [], 'latest': False}]},
         ]
@@ -2179,7 +2179,7 @@ class TestEntityRunExperiment:
         assert response.status_code == 200
         assert response.context['object_list'] == [{'id': protocol.pk,
                                                     'entity': protocol,
-                                                    'name': 'myprotocol1',
+                                                    'name': protocol.name,
                                                     'versions': [{'commit': version2, 'tags': ['v1'], 'latest': True},
                                                                  {'commit': version1, 'tags': [], 'latest': False}]},
                                                    ]
@@ -2229,7 +2229,7 @@ class TestEntityRunExperiment:
         assert response.status_code == 200
         assert response.context['object_list'] == [{'id': protocol.pk,
                                                     'entity': protocol,
-                                                    'name': 'myprotocol1',
+                                                    'name': protocol.name,
                                                     'versions': [{'commit': version2, 'tags': ['v1'], 'latest': True},
                                                                  {'commit': version1, 'tags': [], 'latest': False}]},
                                                    ]
@@ -2281,14 +2281,14 @@ class TestEntityRunExperiment:
         assert response.status_code == 200
         assert response.context['object_list'] == [{'id': protocol.pk,
                                                     'entity': protocol,
-                                                    'name': 'myprotocol1',
+                                                    'name': protocol.name,
                                                     'versions': [{'commit': version2, 'tags': ['v1'], 'latest': True},
                                                                  {'commit': version1, 'tags': [], 'latest': False}]},
                                                    ]
         assert response.context['other_object_list'] == [
             {'id': other_protocol.pk,
              'entity': other_protocol,
-             'name': 'myprotocol2',
+             'name': other_protocol.name,
              'versions': [{'commit': other_version2, 'tags': ['v1'], 'latest': True},
                           {'commit': other_version1, 'tags': [], 'latest': False}]},
         ]
@@ -2338,7 +2338,7 @@ class TestEntityRunExperiment:
         assert response.status_code == 200
         assert response.context['object_list'] == [{'id': protocol.pk,
                                                     'entity': protocol,
-                                                    'name': 'myprotocol1',
+                                                    'name': protocol.name,
                                                     'versions': [{'commit': version2, 'tags': ['v1'], 'latest': True},
                                                                  {'commit': version1, 'tags': [], 'latest': False}]},
                                                    ]
@@ -2384,7 +2384,7 @@ class TestEntityRunExperiment:
         assert response.status_code == 200
         assert response.context['object_list'] == [{'id': model.pk,
                                                     'entity': model,
-                                                    'name': 'mymodel1',
+                                                    'name': model.name,
                                                     'versions': [{'commit': version2, 'tags': ['v1'], 'latest': True},
                                                                  {'commit': version1, 'tags': [], 'latest': False}]},
                                                    ]
@@ -2416,14 +2416,14 @@ class TestEntityRunExperiment:
         assert response.status_code == 200
         assert response.context['object_list'] == [{'id': model.pk,
                                                     'entity': model,
-                                                    'name': 'mymodel1',
+                                                    'name': model.name,
                                                     'versions': [{'commit': version2, 'tags': ['v1'], 'latest': True},
                                                                  {'commit': version1, 'tags': [], 'latest': False}]},
                                                    ]
         assert response.context['other_object_list'] == [
             {'id': other_model.pk,
              'entity': other_model,
-             'name': 'mymodel2',
+             'name': other_model.name,
              'versions': [{'commit': other_version2, 'tags': ['v1'], 'latest': True},
                           {'commit': other_version1, 'tags': [], 'latest': False}]},
         ]
@@ -2446,7 +2446,7 @@ class TestEntityRunExperiment:
         assert response.status_code == 200
         assert response.context['object_list'] == [{'id': model.pk,
                                                     'entity': model,
-                                                    'name': 'mymodel1',
+                                                    'name': model.name,
                                                     'versions': [{'commit': version2, 'tags': ['v1'], 'latest': True},
                                                                  {'commit': version1, 'tags': [], 'latest': False}]},
                                                    ]
@@ -2502,7 +2502,7 @@ class TestEntityRunExperiment:
         assert response.status_code == 200
         assert response.context['object_list'] == [{'id': model.pk,
                                                     'entity': model,
-                                                    'name': 'mymodel1',
+                                                    'name': model.name,
                                                     'versions': [{'commit': version2, 'tags': ['v1'], 'latest': True},
                                                                  {'commit': version1, 'tags': [], 'latest': False}]},
                                                    ]
@@ -2551,14 +2551,14 @@ class TestEntityRunExperiment:
         assert response.status_code == 200
         assert response.context['object_list'] == [{'id': model.pk,
                                                     'entity': model,
-                                                    'name': 'mymodel1',
+                                                    'name': model.name,
                                                     'versions': [{'commit': version2, 'tags': ['v1'], 'latest': True},
                                                                  {'commit': version1, 'tags': [], 'latest': False}]},
                                                    ]
         assert response.context['other_object_list'] == [
             {'id': other_model.pk,
              'entity': other_model,
-             'name': 'mymodel2',
+             'name': other_model.name,
              'versions': [{'commit': other_version2, 'tags': ['v1'], 'latest': True},
                           {'commit': other_version1, 'tags': [], 'latest': False}]},
         ]
@@ -2605,7 +2605,7 @@ class TestEntityRunExperiment:
         assert response.status_code == 200
         assert response.context['object_list'] == [{'id': protocol.pk,
                                                     'entity': protocol,
-                                                    'name': 'myprotocol1',
+                                                    'name': protocol.name,
                                                     'versions': [{'commit': version2, 'tags': ['v1'], 'latest': True},
                                                                  {'commit': version1, 'tags': [], 'latest': False}]},
                                                    ]
@@ -2653,7 +2653,7 @@ class TestEntityRunExperiment:
         assert response.status_code == 200
         assert response.context['object_list'] == [{'id': model.pk,
                                                     'entity': model,
-                                                    'name': 'mymodel1',
+                                                    'name': model.name,
                                                     'versions': [{'commit': version2, 'tags': ['v1'], 'latest': True},
                                                                  {'commit': version1, 'tags': [], 'latest': False}]},
                                                    ]

--- a/weblab/experiments/tests/test_views.py
+++ b/weblab/experiments/tests/test_views.py
@@ -13,6 +13,7 @@ from django.contrib.messages import get_messages
 from django.core.urlresolvers import reverse
 from django.test import Client
 from django.utils.dateparse import parse_datetime
+from pytest_django.asserts import assertContains, assertTemplateUsed
 
 from core import recipes
 from experiments.models import (
@@ -950,8 +951,11 @@ class TestExperimentVersionView:
                                               experiment_version.pk))
         )
 
-        assert response.status_code == 200
         assert response.context['version'] == experiment_version
+        assertTemplateUsed(response, 'experiments/experimentversion_detail.html')
+        assertContains(response, 'Download archive of all files')
+        print(response.content)
+        assert False
 
 
 @pytest.mark.django_db

--- a/weblab/experiments/tests/test_views.py
+++ b/weblab/experiments/tests/test_views.py
@@ -954,8 +954,6 @@ class TestExperimentVersionView:
         assert response.context['version'] == experiment_version
         assertTemplateUsed(response, 'experiments/experimentversion_detail.html')
         assertContains(response, 'Download archive of all files')
-        print(response.content)
-        assert False
 
 
 @pytest.mark.django_db

--- a/weblab/templates/experiments/experimentversion_detail.html
+++ b/weblab/templates/experiments/experimentversion_detail.html
@@ -45,9 +45,9 @@
         {% endif %}
 
         <br/>Corresponding model:
-        <a href="{% url 'entities:version' 'model' experiment.model.pk experiment.model_version %}">{{ experiment.model.name }} @ {{ experiment.nice_model_version }}</a>
+        <a href="{% url 'entities:version' 'model' experiment.model.pk experiment.model_version.sha %}">{{ experiment.model.name }} @ {{ experiment.nice_model_version }}</a>
           &amp; protocol:
-          <a href="{% url 'entities:version' 'protocol' experiment.protocol.pk experiment.protocol_version %}">{{ experiment.protocol.name }} @ {{ experiment.nice_protocol_version }}</a>
+          <a href="{% url 'entities:version' 'protocol' experiment.protocol.pk experiment.protocol_version.sha %}">{{ experiment.protocol.name }} @ {{ experiment.nice_protocol_version }}</a>
 
       </small>
     </div>

--- a/weblab/templates/experiments/experimentversion_detail.html
+++ b/weblab/templates/experiments/experimentversion_detail.html
@@ -45,9 +45,9 @@
         {% endif %}
 
         <br/>Corresponding model:
-        <a href="{% url 'entities:version' 'model' experiment.model.pk experiment.model_version.sha %}">{{ experiment.model.name }} @ {{ experiment.nice_model_version }}</a>
+        <a href="{% url 'entities:version' 'model' experiment.model.pk experiment.model_version %}">{{ experiment.model.name }} @ {{ experiment.nice_model_version }}</a>
           &amp; protocol:
-          <a href="{% url 'entities:version' 'protocol' experiment.protocol.pk experiment.protocol_version.sha %}">{{ experiment.protocol.name }} @ {{ experiment.nice_protocol_version }}</a>
+          <a href="{% url 'entities:version' 'protocol' experiment.protocol.pk experiment.protocol_version %}">{{ experiment.protocol.name }} @ {{ experiment.nice_protocol_version }}</a>
 
       </small>
     </div>


### PR DESCRIPTION
@sroderick-g5sro I did a little playing while waiting for tests to run. Looks like the templates are rendered, but they don't check that reverse URL lookups actually exist! So you get the following in the HTML:

```
Corresponding model:\n        <a href="/entities/models/1/versions/mymodel1@9eecdce802a30253b89b3701c5f0d6006e7787a5">mymodel1 @ 9eecdce8...</a>
```

Instead of the expected:

```
Corresponding model:\n        <a href="/entities/models/1/versions/9eecdce802a30253b89b3701c5f0d6006e7787a5">mymodel1 @ 9eecdce8...</a>
```

Not sure how you'd check for that without having to hard-code every instance, but maybe you can find something!