### PR TITLE
Add a link to WL1 on the front page

### DIFF
--- a/weblab/templates/home.html
+++ b/weblab/templates/home.html
@@ -9,7 +9,8 @@
 
   <p>
     This is the beta version of 'Web Lab 2', a second generation Web Lab incorporating experimental data and parameter fitting.
-    You can read more about our plans in a <a href="https://www.biorxiv.org/content/early/2018/01/31/257683">preprint of our next Web Lab paper</a>.
+    You can read more about our plans in a <a href="https://www.biorxiv.org/content/early/2018/01/31/257683">preprint of our Web Lab 2 paper</a>.
+    The <a href="https://travis.cs.ox.ac.uk/FunctionalCuration/">original Web Lab 1</a> is also still available.
   </p>
 
   <h2>Quick start links</h2>


### PR DESCRIPTION
The redirect at https://chaste.cs.ox.ac.uk/WebLab now redirects to WL2, so we need a way for users to find the original while it is still available.

This branch is now deployed on https://scrambler.cs.ox.ac.uk/