### PR TITLE
Fix GitHub deprecated api

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -4,7 +4,7 @@ Django==1.11.29
 psycopg2==2.7.3
 
 # Social authentication
-social-auth-app-django==1.2.0
+social-auth-app-django==4.0.0
 
 # Parse database URLs from environment
 dj-database-url==0.4.2

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,7 +5,9 @@
 #    pip-compile --output-file=base.txt base.in
 #
 certifi==2019.3.9         # via requests
+cffi==1.14.3              # via cryptography
 chardet==3.0.4            # via requests
+cryptography==3.1.1       # via social-auth-core
 defusedxml==0.5.0         # via python3-openid, social-auth-core
 dj-database-url==0.4.2    # via -r base.in
 django-braces==1.11.0     # via -r base.in
@@ -16,14 +18,15 @@ gitpython==2.1.7          # via -r base.in
 idna==2.8                 # via requests
 oauthlib==3.0.1           # via requests-oauthlib, social-auth-core
 psycopg2==2.7.3           # via -r base.in
+pycparser==2.20           # via cffi
 pyjwt==1.7.1              # via social-auth-core
 python3-openid==3.1.0     # via social-auth-core
 pytz==2018.9              # via django
 requests-oauthlib==1.2.0  # via social-auth-core
 requests==2.21.0          # via requests-oauthlib, rollbar, social-auth-core
 rollbar==0.14.2           # via -r base.in
-six==1.12.0               # via django-guardian, rollbar, social-auth-app-django, social-auth-core
+six==1.12.0               # via cryptography, django-guardian, rollbar, social-auth-app-django, social-auth-core
 smmap2==2.0.5             # via gitdb2
-social-auth-app-django==1.2.0  # via -r base.in
-social-auth-core==3.1.0   # via social-auth-app-django
+social-auth-app-django==4.0.0  # via -r base.in
+social-auth-core==3.3.3   # via social-auth-app-django
 urllib3==1.24.2           # via requests

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -3,6 +3,6 @@
 
 appnope; sys_platform=='darwin'
 ipdb
-pip-tools
+pip-tools==5.2.1
 flake8
 isort

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -3,6 +3,6 @@
 
 appnope; sys_platform=='darwin'
 ipdb
-pip-tools==5.2.1
+pip-tools>=5.2.1
 flake8
 isort

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -36,7 +36,7 @@ oauthlib==3.0.1           # via requests-oauthlib, social-auth-core
 parso==0.3.4              # via jedi
 pexpect==4.6.0            # via ipython
 pickleshare==0.7.5        # via ipython
-pip-tools==5.2.1          # via -r dev.in
+pip-tools==5.3.1          # via -r dev.in
 pluggy==0.6.0             # via pytest
 prompt-toolkit==2.0.9     # via ipython
 psycopg2==2.7.3           # via -r base.in

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,10 +8,12 @@ atomicwrites==1.4.0       # via pytest
 attrs==20.2.0             # via pytest
 backcall==0.1.0           # via ipython
 certifi==2019.3.9         # via requests
+cffi==1.14.3              # via cryptography
 chardet==3.0.4            # via requests
 click==7.0                # via pip-tools
 codecov==2.0.15           # via -r test.in
 coverage==4.5.3           # via codecov, pytest-cov
+cryptography==3.1.1       # via social-auth-core
 decorator==4.4.0          # via ipython, traitlets
 defusedxml==0.5.0         # via python3-openid, social-auth-core
 dj-database-url==0.4.2    # via -r base.in
@@ -41,6 +43,7 @@ psycopg2==2.7.3           # via -r base.in
 ptyprocess==0.6.0         # via pexpect
 py==1.8.0                 # via pytest
 pycodestyle==2.3.1        # via flake8
+pycparser==2.20           # via cffi
 pyflakes==1.5.0           # via flake8
 pygments==2.3.1           # via ipython
 pyjwt==1.7.1              # via social-auth-core
@@ -52,10 +55,10 @@ pytz==2018.9              # via django
 requests-oauthlib==1.2.0  # via social-auth-core
 requests==2.21.0          # via codecov, requests-oauthlib, rollbar, social-auth-core
 rollbar==0.14.2           # via -r base.in
-six==1.12.0               # via django-guardian, model-mommy, pip-tools, prompt-toolkit, pytest, rollbar, social-auth-app-django, social-auth-core, traitlets
+six==1.12.0               # via cryptography, django-guardian, model-mommy, pip-tools, prompt-toolkit, pytest, rollbar, social-auth-app-django, social-auth-core, traitlets
 smmap2==2.0.5             # via gitdb2
-social-auth-app-django==1.2.0  # via -r base.in
-social-auth-core==3.1.0   # via social-auth-app-django
+social-auth-app-django==4.0.0  # via -r base.in
+social-auth-core==3.3.3   # via social-auth-app-django
 traitlets==4.3.2          # via ipython
 urllib3==1.24.2           # via requests
 wcwidth==0.1.7            # via prompt-toolkit

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,58 +4,62 @@
 #
 #    pip-compile --output-file=dev.txt dev.in
 #
-appnope==0.1.0 ; sys_platform == "darwin"
+atomicwrites==1.4.0       # via pytest
+attrs==20.2.0             # via pytest
 backcall==0.1.0           # via ipython
 certifi==2019.3.9         # via requests
 chardet==3.0.4            # via requests
 click==7.0                # via pip-tools
-codecov==2.0.15
+codecov==2.0.15           # via -r test.in
 coverage==4.5.3           # via codecov, pytest-cov
 decorator==4.4.0          # via ipython, traitlets
 defusedxml==0.5.0         # via python3-openid, social-auth-core
-dj-database-url==0.4.2
-django-braces==1.11.0
-django-guardian==1.4.9
-django==1.11.28
-flake8==3.4.1
+dj-database-url==0.4.2    # via -r base.in
+django-braces==1.11.0     # via -r base.in
+django-guardian==1.4.9    # via -r base.in
+django==1.11.29           # via -r base.in, model-mommy
+flake8==3.4.1             # via -r dev.in, -r test.in
 gitdb2==2.0.5             # via gitpython
-gitpython==2.1.7
+gitpython==2.1.7          # via -r base.in
 idna==2.8                 # via requests
-ipdb==0.12
+ipdb==0.12                # via -r dev.in
 ipython-genutils==0.2.0   # via traitlets
 ipython==7.4.0            # via ipdb
-isort==4.2.15
+isort==4.2.15             # via -r dev.in, -r test.in
 jedi==0.13.3              # via ipython
 mccabe==0.6.1             # via flake8
-model-mommy==1.5.1
+model-mommy==1.5.1        # via -r test.in
+more-itertools==8.5.0     # via pytest
 oauthlib==3.0.1           # via requests-oauthlib, social-auth-core
 parso==0.3.4              # via jedi
 pexpect==4.6.0            # via ipython
 pickleshare==0.7.5        # via ipython
-pip-tools==4.3.0
+pip-tools==5.2.1          # via -r dev.in
+pluggy==0.6.0             # via pytest
 prompt-toolkit==2.0.9     # via ipython
-psycopg2==2.7.3
+psycopg2==2.7.3           # via -r base.in
 ptyprocess==0.6.0         # via pexpect
 py==1.8.0                 # via pytest
 pycodestyle==2.3.1        # via flake8
 pyflakes==1.5.0           # via flake8
 pygments==2.3.1           # via ipython
 pyjwt==1.7.1              # via social-auth-core
-pytest-cov==2.5.1
-pytest-django==3.1.2
-pytest==3.2.0
+pytest-cov==2.5.1         # via -r test.in
+pytest-django==3.8.0      # via -r test.in
+pytest==3.6.0             # via -r test.in, pytest-cov, pytest-django
 python3-openid==3.1.0     # via social-auth-core
 pytz==2018.9              # via django
 requests-oauthlib==1.2.0  # via social-auth-core
 requests==2.21.0          # via codecov, requests-oauthlib, rollbar, social-auth-core
-rollbar==0.14.2
-six==1.12.0               # via django-guardian, model-mommy, pip-tools, prompt-toolkit, rollbar, social-auth-app-django, social-auth-core, traitlets
+rollbar==0.14.2           # via -r base.in
+six==1.12.0               # via django-guardian, model-mommy, pip-tools, prompt-toolkit, pytest, rollbar, social-auth-app-django, social-auth-core, traitlets
 smmap2==2.0.5             # via gitdb2
-social-auth-app-django==1.2.0
+social-auth-app-django==1.2.0  # via -r base.in
 social-auth-core==3.1.0   # via social-auth-app-django
 traitlets==4.3.2          # via ipython
 urllib3==1.24.2           # via requests
 wcwidth==0.1.7            # via prompt-toolkit
 
 # The following packages are considered to be unsafe in a requirements file:
+# pip
 # setuptools

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,10 +4,14 @@
 #
 #    pip-compile --output-file=test.txt test.in
 #
+atomicwrites==1.4.0       # via pytest
+attrs==20.2.0             # via pytest
 certifi==2019.3.9         # via requests
+cffi==1.14.3              # via cryptography
 chardet==3.0.4            # via requests
 codecov==2.0.15           # via -r test.in
 coverage==4.5.3           # via codecov, pytest-cov
+cryptography==3.1.1       # via social-auth-core
 defusedxml==0.5.0         # via python3-openid, social-auth-core
 dj-database-url==0.4.2    # via -r base.in
 django-braces==1.11.0     # via -r base.in
@@ -21,10 +25,13 @@ idna==2.8                 # via requests
 isort==4.3.21             # via -r test.in
 mccabe==0.6.1             # via flake8
 model-mommy==1.5.1        # via -r test.in
+more-itertools==8.5.0     # via pytest
 oauthlib==3.0.1           # via requests-oauthlib, social-auth-core
+pluggy==0.6.0             # via pytest
 psycopg2==2.7.3           # via -r base.in
 py==1.8.0                 # via pytest
 pycodestyle==2.5.0        # via flake8
+pycparser==2.20           # via cffi
 pyflakes==2.1.1           # via flake8
 pyjwt==1.7.1              # via social-auth-core
 pytest-cov==2.5.1         # via -r test.in
@@ -35,10 +42,10 @@ pytz==2018.9              # via django
 requests-oauthlib==1.2.0  # via social-auth-core
 requests==2.21.0          # via codecov, requests-oauthlib, rollbar, social-auth-core
 rollbar==0.14.2           # via -r base.in
-six==1.12.0               # via django-guardian, model-mommy, rollbar, social-auth-app-django, social-auth-core
+six==1.12.0               # via cryptography, django-guardian, model-mommy, pytest, rollbar, social-auth-app-django, social-auth-core
 smmap2==2.0.5             # via gitdb2
-social-auth-app-django==1.2.0  # via -r base.in
-social-auth-core==3.1.0   # via social-auth-app-django
+social-auth-app-django==4.0.0  # via -r base.in
+social-auth-core==3.3.3   # via social-auth-app-django
 urllib3==1.24.2           # via requests
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
This fixes #273 - fortunately this seems to just be a matter of upgrading social-auth-app-django and Django 1.11 is still being supported / tested by this component. I've tested it and github login seems to still work.

This also includes pinning the version of pip-tools since older versions won't work with newer versions of pip.