### PR TITLE
Fitting results matrix

### DIFF
--- a/weblab/conftest.py
+++ b/weblab/conftest.py
@@ -276,6 +276,7 @@ def queued_fittingresult(public_model, public_protocol, public_fittingspec, publ
     recipes.running_experiment.make(runnable=version)
     return version
 
+
 @pytest.fixture
 def quick_fittingresult_version(helpers):
     """A fitting result version that exists only in the DB - no repos, no results."""

--- a/weblab/conftest.py
+++ b/weblab/conftest.py
@@ -264,6 +264,26 @@ def queued_fittingresult(public_model, public_protocol, public_fittingspec, publ
     recipes.running_experiment.make(runnable=version)
     return version
 
+@pytest.fixture
+def quick_fittingresult_version(helpers):
+    """A fitting result version that exists only in the DB - no repos, no results."""
+    model = recipes.model.make()
+    model_version = helpers.add_fake_version(model, 'public')
+    protocol = recipes.protocol.make()
+    protocol_version = helpers.add_fake_version(protocol, 'public')
+    fittingspec = recipes.fittingspec.make()
+    fittingspec_version = helpers.add_fake_version(fittingspec, 'public')
+    dataset = recipes.dataset.make(visibility='public')
+    return recipes.fittingresult_version.make(
+        status='SUCCESS',
+        fittingresult__model=model,
+        fittingresult__model_version=model_version,
+        fittingresult__protocol=protocol,
+        fittingresult__protocol_version=protocol_version,
+        fittingresult__fittingspec=fittingspec,
+        fittingresult__fittingspec_version=fittingspec_version,
+        fittingresult__dataset=dataset,
+    )
 
 @pytest.fixture
 def experiment_with_result(model_with_version, protocol_with_version):

--- a/weblab/conftest.py
+++ b/weblab/conftest.py
@@ -479,6 +479,8 @@ def my_dataset_with_file(logged_in_user, helpers, public_protocol, client):
 
 @pytest.fixture
 def fittingresult_version(public_model, public_protocol, public_fittingspec, public_dataset):
+    public_dataset.protocol = public_protocol
+    public_dataset.save()
     return recipes.fittingresult_version.make(
         status='SUCCESS',
         fittingresult__model=public_model,

--- a/weblab/conftest.py
+++ b/weblab/conftest.py
@@ -271,9 +271,9 @@ def quick_fittingresult_version(helpers):
     model_version = helpers.add_fake_version(model, 'public')
     protocol = recipes.protocol.make()
     protocol_version = helpers.add_fake_version(protocol, 'public')
-    fittingspec = recipes.fittingspec.make()
+    fittingspec = recipes.fittingspec.make(protocol=protocol)
     fittingspec_version = helpers.add_fake_version(fittingspec, 'public')
-    dataset = recipes.dataset.make(visibility='public')
+    dataset = recipes.dataset.make(visibility='public', protocol=protocol)
     return recipes.fittingresult_version.make(
         status='SUCCESS',
         fittingresult__model=model,

--- a/weblab/conftest.py
+++ b/weblab/conftest.py
@@ -480,6 +480,8 @@ def my_dataset_with_file(logged_in_user, helpers, public_protocol, client):
 
 @pytest.fixture
 def fittingresult_version(public_model, public_protocol, public_fittingspec, public_dataset):
+    public_fittingspec.protocol = public_protocol
+    public_fittingspec.save()
     public_dataset.protocol = public_protocol
     public_dataset.save()
     return recipes.fittingresult_version.make(

--- a/weblab/conftest.py
+++ b/weblab/conftest.py
@@ -211,6 +211,18 @@ def moderated_protocol(helpers):
 
 
 @pytest.fixture
+def moderated_fittingspec(helpers):
+    fittingspec = recipes.fittingspec.make()
+    helpers.add_version(fittingspec, visibility='moderated')
+    return fittingspec
+
+
+@pytest.fixture
+def moderated_dataset(helpers):
+    return recipes.dataset.make(visibility='moderated')
+
+
+@pytest.fixture
 def private_model(helpers):
     model = recipes.model.make(name='private model')
     helpers.add_version(model, visibility='private')
@@ -284,6 +296,22 @@ def quick_fittingresult_version(helpers):
         fittingresult__fittingspec_version=fittingspec_version,
         fittingresult__dataset=dataset,
     )
+
+
+@pytest.fixture
+def moderated_fittingresult_version(moderated_model, moderated_protocol,
+                                    moderated_fittingspec, moderated_dataset):
+    return recipes.fittingresult_version.make(
+        status='SUCCESS',
+        fittingresult__model=moderated_model,
+        fittingresult__model_version=moderated_model.repocache.latest_version,
+        fittingresult__protocol=moderated_protocol,
+        fittingresult__protocol_version=moderated_protocol.repocache.latest_version,
+        fittingresult__fittingspec=moderated_fittingspec,
+        fittingresult__fittingspec_version=moderated_fittingspec.repocache.latest_version,
+        fittingresult__dataset=moderated_dataset,
+    )
+
 
 @pytest.fixture
 def experiment_with_result(model_with_version, protocol_with_version):

--- a/weblab/experiments/tests/test_views.py
+++ b/weblab/experiments/tests/test_views.py
@@ -420,7 +420,7 @@ class TestExperimentMatrix:
             {
                 'subset': 'all',
                 'modelIds[]': [exp.model.pk, non_existent_pk],
-                'protoIds[]': [exp.protocol.pk, non_existent_pk],
+                'columnIds[]': [exp.protocol.pk, non_existent_pk],
             }
         )
 
@@ -540,8 +540,8 @@ class TestExperimentMatrix:
             '/experiments/matrix',
             {
                 'subset': 'all',
-                'protoIds[]': [exp.protocol.pk],
-                'protoVersions[]': [str(v1.sha), str(v2.sha)],
+                'columnIds[]': [exp.protocol.pk],
+                'columnVersions[]': [str(v1.sha), str(v2.sha)],
             }
         )
 
@@ -573,8 +573,8 @@ class TestExperimentMatrix:
             '/experiments/matrix',
             {
                 'subset': 'all',
-                'protoIds[]': [exp.protocol.pk],
-                'protoVersions[]': '*',
+                'columnIds[]': [exp.protocol.pk],
+                'columnVersions[]': '*',
             }
         )
 
@@ -592,8 +592,8 @@ class TestExperimentMatrix:
             '/experiments/matrix',
             {
                 'subset': 'all',
-                'protoIds[]': [quick_experiment_version.experiment.protocol.pk, protocol.pk],
-                'protoVersions[]': '*',
+                'columnIds[]': [quick_experiment_version.experiment.protocol.pk, protocol.pk],
+                'columnVersions[]': '*',
             }
         )
 
@@ -623,8 +623,8 @@ class TestExperimentMatrix:
                 'subset': 'all',
                 'modelIds[]': [m1.pk],
                 'modelVersions[]': '*',
-                'protoIds[]': [p1.pk],
-                'protoVersions[]': '*',
+                'columnIds[]': [p1.pk],
+                'columnVersions[]': '*',
             }
         )
 
@@ -642,8 +642,8 @@ class TestExperimentMatrix:
                 'subset': 'all',
                 'modelIds[]': [m1.pk],
                 'modelVersions[]': [str(m1v1.sha)],
-                'protoIds[]': [p1.pk],
-                'protoVersions[]': [str(p1v1.sha)],
+                'columnIds[]': [p1.pk],
+                'columnVersions[]': [str(p1v1.sha)],
             }
         )
 

--- a/weblab/experiments/tests/test_views.py
+++ b/weblab/experiments/tests/test_views.py
@@ -139,8 +139,8 @@ class TestExperimentMatrix:
 
         assert len(data['getMatrix']['models']) == 1
         assert str(exp.model_version.sha) in data['getMatrix']['models']
-        assert len(data['getMatrix']['protocols']) == 1
-        assert str(exp.protocol_version.sha) in data['getMatrix']['protocols']
+        assert len(data['getMatrix']['columns']) == 1
+        assert str(exp.protocol_version.sha) in data['getMatrix']['columns']
         assert len(data['getMatrix']['experiments']) == 1
         assert str(exp.pk) in data['getMatrix']['experiments']
 
@@ -166,7 +166,7 @@ class TestExperimentMatrix:
         data = json.loads(response.content.decode())
         assert 'getMatrix' in data
         assert len(data['getMatrix']['models']) == 0
-        assert len(data['getMatrix']['protocols']) == 1
+        assert len(data['getMatrix']['columns']) == 1
         assert len(data['getMatrix']['experiments']) == 0
 
     def test_view_my_experiments_with_moderated_flags(
@@ -434,7 +434,7 @@ class TestExperimentMatrix:
         assert models[str(exp.model_version.sha)]['id'] == str(exp.model_version.sha)
         assert models[str(exp.model_version.sha)]['entityId'] == exp.model.pk
 
-        protocols = data['getMatrix']['protocols']
+        protocols = data['getMatrix']['columns']
         assert len(protocols) == 1
         assert str(exp.protocol_version.sha) in protocols
         assert protocols[str(exp.protocol_version.sha)]['id'] == str(exp.protocol_version.sha)
@@ -549,7 +549,7 @@ class TestExperimentMatrix:
         data = json.loads(response.content.decode())
         assert 'getMatrix' in data
 
-        assert set(data['getMatrix']['protocols'].keys()) == {str(v1.sha), str(v2.sha)}
+        assert set(data['getMatrix']['columns'].keys()) == {str(v1.sha), str(v2.sha)}
         assert set(data['getMatrix']['experiments'].keys()) == {str(exp.pk), str(exp2.pk)}
 
     def test_submatrix_with_all_protocol_versions(self, client, helpers, quick_experiment_version):
@@ -582,7 +582,7 @@ class TestExperimentMatrix:
         data = json.loads(response.content.decode())
         assert 'getMatrix' in data
 
-        assert set(data['getMatrix']['protocols'].keys()) == {str(v1.sha), str(v2.sha), str(v3.sha)}
+        assert set(data['getMatrix']['columns'].keys()) == {str(v1.sha), str(v2.sha), str(v3.sha)}
         assert set(data['getMatrix']['experiments'].keys()) == {str(exp.pk), str(exp2.pk)}
 
     def test_submatrix_with_too_many_protocol_ids(self, client, helpers, quick_experiment_version):
@@ -632,7 +632,7 @@ class TestExperimentMatrix:
         data = json.loads(response.content.decode())
         assert 'getMatrix' in data
         assert set(data['getMatrix']['models'].keys()) == {str(m1v1.sha), str(m1v2.sha)}
-        assert set(data['getMatrix']['protocols'].keys()) == {str(p1v1.sha), str(p1v2.sha)}
+        assert set(data['getMatrix']['columns'].keys()) == {str(p1v1.sha), str(p1v2.sha)}
         assert set(data['getMatrix']['experiments'].keys()) == {str(exp1.pk), str(exp2.pk)}
 
         # Now select only some versions
@@ -651,7 +651,7 @@ class TestExperimentMatrix:
         data = json.loads(response.content.decode())
         assert 'getMatrix' in data
         assert set(data['getMatrix']['models'].keys()) == {str(m1v1.sha)}
-        assert set(data['getMatrix']['protocols'].keys()) == {str(p1v1.sha)}
+        assert set(data['getMatrix']['columns'].keys()) == {str(p1v1.sha)}
         assert set(data['getMatrix']['experiments'].keys()) == {str(exp1.pk)}
 
     def test_experiment_without_version_is_ignored(
@@ -667,7 +667,7 @@ class TestExperimentMatrix:
         response = client.get('/experiments/matrix?subset=all')
         assert response.status_code == 200
         data = json.loads(response.content.decode())
-        assert len(data['getMatrix']['protocols']) == 1
+        assert len(data['getMatrix']['columns']) == 1
         assert len(data['getMatrix']['experiments']) == 0
 
     def test_old_version_is_hidden(self, client, public_model, experiment_version, helpers):
@@ -679,7 +679,7 @@ class TestExperimentMatrix:
         data = json.loads(response.content.decode())
         assert 'getMatrix' in data
         assert str(new_version.sha) in data['getMatrix']['models']
-        assert str(experiment_version.experiment.protocol_version.sha) in data['getMatrix']['protocols']
+        assert str(experiment_version.experiment.protocol_version.sha) in data['getMatrix']['columns']
         assert len(data['getMatrix']['experiments']) == 0
 
 

--- a/weblab/experiments/tests/test_views.py
+++ b/weblab/experiments/tests/test_views.py
@@ -137,8 +137,8 @@ class TestExperimentMatrix:
         data = json.loads(response.content.decode())
         assert 'getMatrix' in data
 
-        assert len(data['getMatrix']['models']) == 1
-        assert str(exp.model_version.sha) in data['getMatrix']['models']
+        assert len(data['getMatrix']['rows']) == 1
+        assert str(exp.model_version.sha) in data['getMatrix']['rows']
         assert len(data['getMatrix']['columns']) == 1
         assert str(exp.protocol_version.sha) in data['getMatrix']['columns']
         assert len(data['getMatrix']['experiments']) == 1
@@ -165,7 +165,7 @@ class TestExperimentMatrix:
         response = client.get('/experiments/matrix?subset=all')
         data = json.loads(response.content.decode())
         assert 'getMatrix' in data
-        assert len(data['getMatrix']['models']) == 0
+        assert len(data['getMatrix']['rows']) == 0
         assert len(data['getMatrix']['columns']) == 1
         assert len(data['getMatrix']['experiments']) == 0
 
@@ -419,7 +419,7 @@ class TestExperimentMatrix:
             '/experiments/matrix',
             {
                 'subset': 'all',
-                'modelIds[]': [exp.model.pk, non_existent_pk],
+                'rowIds[]': [exp.model.pk, non_existent_pk],
                 'columnIds[]': [exp.protocol.pk, non_existent_pk],
             }
         )
@@ -428,7 +428,7 @@ class TestExperimentMatrix:
         data = json.loads(response.content.decode())
         assert 'getMatrix' in data
 
-        models = data['getMatrix']['models']
+        models = data['getMatrix']['rows']
         assert len(models) == 1
         assert str(exp.model_version.sha) in models
         assert models[str(exp.model_version.sha)]['id'] == str(exp.model_version.sha)
@@ -459,8 +459,8 @@ class TestExperimentMatrix:
             '/experiments/matrix',
             {
                 'subset': 'all',
-                'modelIds[]': [exp.model.pk],
-                'modelVersions[]': [str(v1.sha), str(v2.sha)],
+                'rowIds[]': [exp.model.pk],
+                'rowVersions[]': [str(v1.sha), str(v2.sha)],
             }
         )
 
@@ -468,7 +468,7 @@ class TestExperimentMatrix:
         data = json.loads(response.content.decode())
         assert 'getMatrix' in data
 
-        assert set(data['getMatrix']['models'].keys()) == {str(v1.sha), str(v2.sha)}
+        assert set(data['getMatrix']['rows'].keys()) == {str(v1.sha), str(v2.sha)}
         assert set(data['getMatrix']['experiments'].keys()) == {str(exp.pk)}
 
     def test_submatrix_with_all_model_versions(self, client, helpers, quick_experiment_version):
@@ -491,8 +491,8 @@ class TestExperimentMatrix:
             '/experiments/matrix',
             {
                 'subset': 'all',
-                'modelIds[]': [exp.model.pk],
-                'modelVersions[]': '*',
+                'rowIds[]': [exp.model.pk],
+                'rowVersions[]': '*',
             }
         )
 
@@ -500,7 +500,7 @@ class TestExperimentMatrix:
         data = json.loads(response.content.decode())
         assert 'getMatrix' in data
 
-        assert set(data['getMatrix']['models'].keys()) == {str(v1.sha), str(v2.sha), str(v3.sha)}
+        assert set(data['getMatrix']['rows'].keys()) == {str(v1.sha), str(v2.sha), str(v3.sha)}
         assert set(data['getMatrix']['experiments'].keys()) == {str(exp.pk), str(exp2.pk)}
 
     def test_submatrix_with_too_many_model_ids(self, client, helpers, quick_experiment_version):
@@ -510,8 +510,8 @@ class TestExperimentMatrix:
             '/experiments/matrix',
             {
                 'subset': 'all',
-                'modelIds[]': [quick_experiment_version.experiment.model.pk, model.pk],
-                'modelVersions[]': '*',
+                'rowIds[]': [quick_experiment_version.experiment.model.pk, model.pk],
+                'rowVersions[]': '*',
             }
         )
 
@@ -621,8 +621,8 @@ class TestExperimentMatrix:
             '/experiments/matrix',
             {
                 'subset': 'all',
-                'modelIds[]': [m1.pk],
-                'modelVersions[]': '*',
+                'rowIds[]': [m1.pk],
+                'rowVersions[]': '*',
                 'columnIds[]': [p1.pk],
                 'columnVersions[]': '*',
             }
@@ -631,7 +631,7 @@ class TestExperimentMatrix:
         assert response.status_code == 200
         data = json.loads(response.content.decode())
         assert 'getMatrix' in data
-        assert set(data['getMatrix']['models'].keys()) == {str(m1v1.sha), str(m1v2.sha)}
+        assert set(data['getMatrix']['rows'].keys()) == {str(m1v1.sha), str(m1v2.sha)}
         assert set(data['getMatrix']['columns'].keys()) == {str(p1v1.sha), str(p1v2.sha)}
         assert set(data['getMatrix']['experiments'].keys()) == {str(exp1.pk), str(exp2.pk)}
 
@@ -640,8 +640,8 @@ class TestExperimentMatrix:
             '/experiments/matrix',
             {
                 'subset': 'all',
-                'modelIds[]': [m1.pk],
-                'modelVersions[]': [str(m1v1.sha)],
+                'rowIds[]': [m1.pk],
+                'rowVersions[]': [str(m1v1.sha)],
                 'columnIds[]': [p1.pk],
                 'columnVersions[]': [str(p1v1.sha)],
             }
@@ -650,7 +650,7 @@ class TestExperimentMatrix:
         assert response.status_code == 200
         data = json.loads(response.content.decode())
         assert 'getMatrix' in data
-        assert set(data['getMatrix']['models'].keys()) == {str(m1v1.sha)}
+        assert set(data['getMatrix']['rows'].keys()) == {str(m1v1.sha)}
         assert set(data['getMatrix']['columns'].keys()) == {str(p1v1.sha)}
         assert set(data['getMatrix']['experiments'].keys()) == {str(exp1.pk)}
 
@@ -678,7 +678,7 @@ class TestExperimentMatrix:
         response = client.get('/experiments/matrix?subset=all')
         data = json.loads(response.content.decode())
         assert 'getMatrix' in data
-        assert str(new_version.sha) in data['getMatrix']['models']
+        assert str(new_version.sha) in data['getMatrix']['rows']
         assert str(experiment_version.experiment.protocol_version.sha) in data['getMatrix']['columns']
         assert len(data['getMatrix']['experiments']) == 0
 

--- a/weblab/experiments/views.py
+++ b/weblab/experiments/views.py
@@ -154,7 +154,6 @@ class ExperimentMatrixJsonView(View):
         model_versions = request.GET.getlist('rowVersions[]')
         protocol_versions = request.GET.getlist('columnVersions[]')
         subset = request.GET.get('subset', 'all' if model_pks or protocol_pks else 'moderated')
-        show_fits = 'show_fits' in request.GET
 
         if model_versions and len(model_pks) > 1:
             return JsonResponse({
@@ -237,10 +236,7 @@ class ExperimentMatrixJsonView(View):
 
         # If specific versions have been requested, show at most those
         q_model_versions = self.versions_query('model', model_versions, q_models, visibility_where)
-        if show_fits:  # Temporary hack
-            protocol_visibility_where = visibility_where & Q(entity__entity__is_fitting_spec=True)
-        else:
-            protocol_visibility_where = visibility_where & Q(entity__entity__is_fitting_spec=False)
+        protocol_visibility_where = visibility_where & Q(entity__entity__is_fitting_spec=False)
         q_protocol_versions = self.versions_query('protocol', protocol_versions, q_protocols, protocol_visibility_where)
 
         # Get the JSON data needed to display the matrix axes

--- a/weblab/experiments/views.py
+++ b/weblab/experiments/views.py
@@ -290,6 +290,7 @@ class ExperimentMatrixJsonView(View):
 
         return JsonResponse({
             'getMatrix': {
+                'columnType': ProtocolEntity.entity_type,
                 'models': model_versions,
                 'columns': protocol_versions,
                 'experiments': experiments,

--- a/weblab/experiments/views.py
+++ b/weblab/experiments/views.py
@@ -291,7 +291,7 @@ class ExperimentMatrixJsonView(View):
         return JsonResponse({
             'getMatrix': {
                 'models': model_versions,
-                'protocols': protocol_versions,
+                'columns': protocol_versions,
                 'experiments': experiments,
             }
         })

--- a/weblab/experiments/views.py
+++ b/weblab/experiments/views.py
@@ -150,9 +150,9 @@ class ExperimentMatrixJsonView(View):
         # Extract and sanity-check call arguments
         user = request.user
         model_pks = list(map(int, request.GET.getlist('modelIds[]')))
-        protocol_pks = list(map(int, request.GET.getlist('protoIds[]')))
+        protocol_pks = list(map(int, request.GET.getlist('columnIds[]')))
         model_versions = request.GET.getlist('modelVersions[]')
-        protocol_versions = request.GET.getlist('protoVersions[]')
+        protocol_versions = request.GET.getlist('columnVersions[]')
         subset = request.GET.get('subset', 'all' if model_pks or protocol_pks else 'moderated')
         show_fits = 'show_fits' in request.GET
 

--- a/weblab/experiments/views.py
+++ b/weblab/experiments/views.py
@@ -149,9 +149,9 @@ class ExperimentMatrixJsonView(View):
     def get(self, request, *args, **kwargs):
         # Extract and sanity-check call arguments
         user = request.user
-        model_pks = list(map(int, request.GET.getlist('modelIds[]')))
+        model_pks = list(map(int, request.GET.getlist('rowIds[]')))
         protocol_pks = list(map(int, request.GET.getlist('columnIds[]')))
-        model_versions = request.GET.getlist('modelVersions[]')
+        model_versions = request.GET.getlist('rowVersions[]')
         protocol_versions = request.GET.getlist('columnVersions[]')
         subset = request.GET.get('subset', 'all' if model_pks or protocol_pks else 'moderated')
         show_fits = 'show_fits' in request.GET
@@ -290,8 +290,7 @@ class ExperimentMatrixJsonView(View):
 
         return JsonResponse({
             'getMatrix': {
-                'columnType': ProtocolEntity.entity_type,
-                'models': model_versions,
+                'rows': model_versions,
                 'columns': protocol_versions,
                 'experiments': experiments,
             }

--- a/weblab/experiments/views.py
+++ b/weblab/experiments/views.py
@@ -72,7 +72,7 @@ class ExperimentMatrixJsonView(View):
     Serve up JSON for experiment matrix
     """
     @classmethod
-    def entity_json(cls, entity, version, *, extend_name, visibility, author, friendly_version=''):
+    def entity_json(cls, entity, version, *, extend_name, visibility, author, friendly_version='', ns='entities'):
         if extend_name:
             name = '%s @ %s' % (entity.name, friendly_version or version)
         else:
@@ -86,8 +86,8 @@ class ExperimentMatrixJsonView(View):
             'created': entity.created_at,
             'name': name,
             'url': reverse(
-                'entities:version',
-                args=[entity.entity_type, entity.id, version]
+                '%s:version' % ns,
+                args=[entity.url_type, entity.id, version]
             ),
         }
 

--- a/weblab/fitting/templatetags/fittings.py
+++ b/weblab/fitting/templatetags/fittings.py
@@ -15,4 +15,3 @@ def url_fitting_comparison_base():
     # between fitting result versions.
     url = reverse('fitting:result:compare', args=['/1/1'])
     return url[:-4]
-

--- a/weblab/fitting/tests/test_views.py
+++ b/weblab/fitting/tests/test_views.py
@@ -469,6 +469,13 @@ class TestCreateFittingResultView:
         assert response.context['form'].initial['model'] == public_model
         assert response.context['form'].initial['model_version'] == version
 
+    def test_with_preselected_model_version_by_sha(self, client, fits_user, public_model):
+        version = public_model.repocache.latest_version
+        response = client.get('/fitting/results/new', {'model_version': version.sha})
+        assert response.status_code == 200
+        assert response.context['form'].initial['model'] == public_model
+        assert response.context['form'].initial['model_version'] == version
+
     def test_with_preselected_protocol_version(self, client, fits_user, public_protocol):
         version = public_protocol.repocache.latest_version
         response = client.get('/fitting/results/new', {'protocol_version': version.pk})
@@ -476,9 +483,23 @@ class TestCreateFittingResultView:
         assert response.context['form'].initial['protocol'] == public_protocol
         assert response.context['form'].initial['protocol_version'] == version
 
+    def test_with_preselected_protocol_version_by_sha(self, client, fits_user, public_protocol):
+        version = public_protocol.repocache.latest_version
+        response = client.get('/fitting/results/new', {'protocol_version': version.sha})
+        assert response.status_code == 200
+        assert response.context['form'].initial['protocol'] == public_protocol
+        assert response.context['form'].initial['protocol_version'] == version
+
     def test_with_preselected_fittingspec_version(self, client, fits_user, public_fittingspec):
         version = public_fittingspec.repocache.latest_version
         response = client.get('/fitting/results/new', {'fittingspec_version': version.pk})
+        assert response.status_code == 200
+        assert response.context['form'].initial['fittingspec'] == public_fittingspec
+        assert response.context['form'].initial['fittingspec_version'] == version
+
+    def test_with_preselected_fittingspec_version_by_sha(self, client, fits_user, public_fittingspec):
+        version = public_fittingspec.repocache.latest_version
+        response = client.get('/fitting/results/new', {'fittingspec_version': version.sha})
         assert response.status_code == 200
         assert response.context['form'].initial['fittingspec'] == public_fittingspec
         assert response.context['form'].initial['fittingspec_version'] == version
@@ -976,8 +997,8 @@ class TestFittingSpecResultsMatrixJsonView:
 
         assert len(data['getMatrix']['models']) == 1
         assert str(fit.model_version.sha) in data['getMatrix']['models']
-        assert len(data['getMatrix']['datasets']) == 1
-        assert str(fit.dataset.id) in data['getMatrix']['datasets']
+        assert len(data['getMatrix']['columns']) == 1
+        assert str(fit.dataset.id) in data['getMatrix']['columns']
         assert len(data['getMatrix']['experiments']) == 1
         assert str(fit.pk) in data['getMatrix']['experiments']
 
@@ -985,4 +1006,5 @@ class TestFittingSpecResultsMatrixJsonView:
         assert fit_data['id'] == quick_fittingresult_version.id
         assert fit_data['entity_id'] == fit.id
         assert fit_data['latestResult'] == quick_fittingresult_version.status
+        assert fit_data['dataset']['id'] == fit.dataset.id
         assert '/fitting/results/%d/versions/%d' % (fit.id, quick_fittingresult_version.id) in fit_data['url']

--- a/weblab/fitting/tests/test_views.py
+++ b/weblab/fitting/tests/test_views.py
@@ -1337,7 +1337,7 @@ class TestFittingSpecResultsMatrixJsonView:
             {
                 'subset': 'all',
                 'modelIds[]': [fit.model.pk, non_existent_pk],
-                'datasetIds[]': [fit.dataset.pk, non_existent_pk],
+                'columnIds[]': [fit.dataset.pk, non_existent_pk],
             }
         )
 

--- a/weblab/fitting/tests/test_views.py
+++ b/weblab/fitting/tests/test_views.py
@@ -1033,8 +1033,8 @@ class TestFittingSpecResultsMatrixJsonView:
         data = json.loads(response.content.decode())
         assert 'getMatrix' in data
 
-        assert len(data['getMatrix']['models']) == 1
-        assert str(fit.model_version.sha) in data['getMatrix']['models']
+        assert len(data['getMatrix']['rows']) == 1
+        assert str(fit.model_version.sha) in data['getMatrix']['rows']
         assert len(data['getMatrix']['columns']) == 1
         assert str(fit.dataset.id) in data['getMatrix']['columns']
         assert len(data['getMatrix']['experiments']) == 1
@@ -1056,7 +1056,7 @@ class TestFittingSpecResultsMatrixJsonView:
         response = client.get('/fitting/specs/%d/results/matrix?subset=all' % fit.fittingspec.pk)
         data = json.loads(response.content.decode())
         assert 'getMatrix' in data
-        assert len(data['getMatrix']['models']) == 0
+        assert len(data['getMatrix']['rows']) == 0
         assert len(data['getMatrix']['columns']) == 1
         assert len(data['getMatrix']['experiments']) == 0
 
@@ -1336,7 +1336,7 @@ class TestFittingSpecResultsMatrixJsonView:
             '/fitting/specs/%d/results/matrix' % spec.pk,
             {
                 'subset': 'all',
-                'modelIds[]': [fit.model.pk, non_existent_pk],
+                'rowIds[]': [fit.model.pk, non_existent_pk],
                 'columnIds[]': [fit.dataset.pk, non_existent_pk],
             }
         )
@@ -1345,7 +1345,7 @@ class TestFittingSpecResultsMatrixJsonView:
         data = json.loads(response.content.decode())
         assert 'getMatrix' in data
 
-        models = data['getMatrix']['models']
+        models = data['getMatrix']['rows']
         assert len(models) == 1
         assert str(fit.model_version.sha) in models
         assert models[str(fit.model_version.sha)]['id'] == str(fit.model_version.sha)
@@ -1377,8 +1377,8 @@ class TestFittingSpecResultsMatrixJsonView:
             '/fitting/specs/%d/results/matrix' % spec.pk,
             {
                 'subset': 'all',
-                'modelIds[]': [fit.model.pk],
-                'modelVersions[]': [str(v1.sha), str(v2.sha)],
+                'rowIds[]': [fit.model.pk],
+                'rowVersions[]': [str(v1.sha), str(v2.sha)],
             }
         )
 
@@ -1386,7 +1386,7 @@ class TestFittingSpecResultsMatrixJsonView:
         data = json.loads(response.content.decode())
         assert 'getMatrix' in data
 
-        assert set(data['getMatrix']['models'].keys()) == {str(v1.sha), str(v2.sha)}
+        assert set(data['getMatrix']['rows'].keys()) == {str(v1.sha), str(v2.sha)}
         assert set(data['getMatrix']['experiments'].keys()) == {str(fit.pk)}
 
     def test_submatrix_with_all_model_versions(self, client, helpers, quick_fittingresult_version):
@@ -1409,8 +1409,8 @@ class TestFittingSpecResultsMatrixJsonView:
             '/fitting/specs/%d/results/matrix' % spec.pk,
             {
                 'subset': 'all',
-                'modelIds[]': [fit.model.pk],
-                'modelVersions[]': '*',
+                'rowIds[]': [fit.model.pk],
+                'rowVersions[]': '*',
             }
         )
 
@@ -1418,7 +1418,7 @@ class TestFittingSpecResultsMatrixJsonView:
         data = json.loads(response.content.decode())
         assert 'getMatrix' in data
 
-        assert set(data['getMatrix']['models'].keys()) == {str(v1.sha), str(v2.sha), str(v3.sha)}
+        assert set(data['getMatrix']['rows'].keys()) == {str(v1.sha), str(v2.sha), str(v3.sha)}
         assert set(data['getMatrix']['experiments'].keys()) == {str(fit.pk), str(fit2.pk)}
 
     def test_submatrix_with_too_many_model_ids(self, client, helpers, quick_fittingresult_version):
@@ -1430,8 +1430,8 @@ class TestFittingSpecResultsMatrixJsonView:
             '/fitting/specs/%d/results/matrix' % spec.pk,
             {
                 'subset': 'all',
-                'modelIds[]': [quick_fittingresult_version.fittingresult.model.pk, model.pk],
-                'modelVersions[]': '*',
+                'rowIds[]': [quick_fittingresult_version.fittingresult.model.pk, model.pk],
+                'rowVersions[]': '*',
             }
         )
 
@@ -1470,6 +1470,6 @@ class TestFittingSpecResultsMatrixJsonView:
         response = client.get('/fitting/specs/%d/results/matrix?subset=all' % fit.fittingspec.pk)
         data = json.loads(response.content.decode())
         assert 'getMatrix' in data
-        assert str(new_version.sha) in data['getMatrix']['models']
+        assert str(new_version.sha) in data['getMatrix']['rows']
         assert str(fit.dataset.pk) in data['getMatrix']['columns']
         assert len(data['getMatrix']['experiments']) == 0

--- a/weblab/fitting/tests/test_views.py
+++ b/weblab/fitting/tests/test_views.py
@@ -1444,7 +1444,8 @@ class TestFittingSpecResultsMatrixJsonView:
     ):
 
         dataset = recipes.dataset.make(visibility='public', protocol=public_protocol)
-        exp = recipes.fittingresult.make(
+        # fitting result with no version
+        recipes.fittingresult.make(
             model=public_model,
             model_version=public_model.repocache.latest_version,
             protocol=public_protocol,

--- a/weblab/fitting/tests/test_views.py
+++ b/weblab/fitting/tests/test_views.py
@@ -954,3 +954,15 @@ class TestFittingSpecResultsMatrixView:
     def test_raises_404_for_non_visible_spec(self, client, private_fittingspec):
         response = client.get('/fitting/specs/%d/results' % private_fittingspec.pk)
         assert response.status_code == 404
+
+@pytest.mark.django_db
+class TestFittingSpecResultsMatrixJsonView:
+    def test_matrix_json_for_fitting_spec(self, client, public_fittingspec):
+        response = client.get('/fitting/specs/%d/results/matrix' % public_fittingspec.pk)
+        assert response.status_code == 200
+        data = json.loads(response.content.decode())
+        assert 'getMatrix' in data
+
+    def test_raises_404_for_non_visible_spec(self, client, private_fittingspec):
+        response = client.get('/fitting/specs/%d/results/matrix' % private_fittingspec.pk)
+        assert response.status_code == 404

--- a/weblab/fitting/tests/test_views.py
+++ b/weblab/fitting/tests/test_views.py
@@ -942,3 +942,15 @@ class TestTransferOwner:
         assert fittingspec.author == other_user
         assert not oldpath.exists()
         assert fittingspec.repo_abs_path.exists()
+
+
+@pytest.mark.django_db
+class TestFittingSpecResultsMatrixView:
+    def test_matrix_page_for_fitting_spec(self, client, public_fittingspec):
+        response = client.get('/fitting/specs/%d/results' % public_fittingspec.pk)
+        assert response.status_code == 200
+        assert response.context['fittingspec'] == public_fittingspec
+
+    def test_raises_404_for_non_visible_spec(self, client, private_fittingspec):
+        response = client.get('/fitting/specs/%d/results' % private_fittingspec.pk)
+        assert response.status_code == 404

--- a/weblab/fitting/tests/test_views.py
+++ b/weblab/fitting/tests/test_views.py
@@ -981,6 +981,33 @@ class TestTransferOwner:
 
 @pytest.mark.django_db
 class TestFittingSpecResultsMatrixView:
+
+
+    @pytest.mark.parametrize("url", [
+        '/fitting/specs/%d/results/',
+        '/fitting/specs/%d/results/mine',
+        '/fitting/specs/%d/results/public',
+        '/fitting/specs/%d/results/all',
+    #    '/experiments/public/models/1/2',
+    #    '/experiments/all/protocols/1/2',
+    #    '/experiments/models/1/2',
+    #    '/experiments/models/1/2/protocols/3/4',
+    #    '/experiments/protocols/1/2',
+    #    '/experiments/models/1/versions/abc/def',
+    #    '/experiments/models/1/versions/*',
+    #    '/experiments/models/1/versions/abc/def/protocols/3/4',
+    #    '/experiments/protocols/3/versions/abc/def',
+    #    '/experiments/protocols/3/versions/*',
+    #    '/experiments/models/1/2/protocols/3/versions/abc/def',
+    ])
+    def test_urls(self, client, url, public_fittingspec):
+        """
+        This is a dumb page that doesn't actually load any data, so we just
+        check that the URLs are working.
+        """
+        response = client.get(url % public_fittingspec.id)
+        assert response.status_code == 200
+
     def test_matrix_page_for_fitting_spec(self, client, public_fittingspec):
         response = client.get('/fitting/specs/%d/results' % public_fittingspec.pk)
         assert response.status_code == 200

--- a/weblab/fitting/tests/test_views.py
+++ b/weblab/fitting/tests/test_views.py
@@ -201,13 +201,14 @@ class TestFittingResultDeletion:
         fittingresult = fittingresult_with_result.fittingresult
         fittingresult.author = logged_in_user
         fittingresult.save()
+        spec = fittingresult.fittingspec
         exp_ver_path = fittingresult_with_result.abs_path
         assert FittingResult.objects.filter(pk=fittingresult.pk).exists()
 
         response = client.post('/fitting/results/%d/delete' % fittingresult.pk)
 
         assert response.status_code == 302
-        assert response.url == '/experiments/?show_fits=true'
+        assert response.url == '/fitting/specs/%d/results' % spec.pk
 
         assert not FittingResult.objects.filter(pk=fittingresult.pk).exists()
         assert not exp_ver_path.exists()

--- a/weblab/fitting/urls.py
+++ b/weblab/fitting/urls.py
@@ -226,6 +226,12 @@ urlpatterns = [
     ),
 
     url(
+        r'^%s/(?P<pk>\d+)/results$' % _ENTITY_TYPE,
+        views.FittingSpecResultsMatrixView.as_view(),
+        name='matrix',
+    ),
+
+    url(
         r'^results/', include(result_patterns, namespace='result')
     ),
 ]

--- a/weblab/fitting/urls.py
+++ b/weblab/fitting/urls.py
@@ -229,7 +229,12 @@ urlpatterns = [
         r'^%s/(?P<pk>\d+)/results'
         '/?'
         r'(?P<subset>mine|public|all)?'
-        r'$' % _ENTITY_TYPE,
+        '/?'
+        r'(?:models(?P<model_pks>(/\d+)+)'
+        '(?:/versions(?P<model_versions>(/%s)+))?)?'
+        '/?'
+        r'(?:datasets(?P<dataset_pks>(/\d+)+))?'
+        r'$' % (_ENTITY_TYPE, _COMMIT),
         views.FittingSpecResultsMatrixView.as_view(),
         name='matrix',
     ),

--- a/weblab/fitting/urls.py
+++ b/weblab/fitting/urls.py
@@ -226,7 +226,10 @@ urlpatterns = [
     ),
 
     url(
-        r'^%s/(?P<pk>\d+)/results$' % _ENTITY_TYPE,
+        r'^%s/(?P<pk>\d+)/results'
+        '/?'
+        r'(?P<subset>mine|public|all)?'
+        r'$' % _ENTITY_TYPE,
         views.FittingSpecResultsMatrixView.as_view(),
         name='matrix',
     ),

--- a/weblab/fitting/urls.py
+++ b/weblab/fitting/urls.py
@@ -232,6 +232,12 @@ urlpatterns = [
     ),
 
     url(
+        r'^%s/(?P<pk>\d+)/results/matrix$' % _ENTITY_TYPE,
+        views.FittingSpecResultsMatrixJsonView.as_view(),
+        name='matrix_json',
+    ),
+
+    url(
         r'^results/', include(result_patterns, namespace='result')
     ),
 ]

--- a/weblab/fitting/views.py
+++ b/weblab/fitting/views.py
@@ -89,7 +89,7 @@ class FittingSpecResultsMatrixJsonView(SingleObjectMixin, ExperimentMatrixJsonVi
             'author': dataset.author.get_full_name(),
             'visibility': dataset.visibility,
             'created': dataset.created_at,
-            'name': dataset.name,
+            'name': "%s (%s)" % (dataset.name, dataset.protocol.name),
             'protocolId': dataset.protocol.id,
             'protocolLatestVersion': dataset.protocol.repocache.latest_version.sha,
             'url': reverse('datasets:detail', args=[dataset.id]),

--- a/weblab/fitting/views.py
+++ b/weblab/fitting/views.py
@@ -227,8 +227,8 @@ class FittingSpecResultsMatrixJsonView(SingleObjectMixin, ExperimentMatrixJsonVi
             'fittingresult',
             'fittingresult__model',
             'fittingresult__model__cachedmodel',
-            'fittingresult__protocol',
             'fittingresult__dataset',
+            'fittingresult__dataset__protocol',
         ).annotate(
             dataset_visibility=F('fittingresult__dataset__visibility'),
             model_visibility=F('fittingresult__model_version__visibility'),

--- a/weblab/fitting/views.py
+++ b/weblab/fitting/views.py
@@ -133,7 +133,7 @@ class FittingSpecResultsMatrixJsonView(SingleObjectMixin, ExperimentMatrixJsonVi
         q_models = ModelEntity.objects.all()
         if model_pks:
             q_models = q_models.filter(id__in=set(model_pks))
-        q_datasets = Dataset.objects.all()
+        q_datasets = Dataset.objects.filter(protocol=spec.protocol)
         if dataset_pks:
             q_datasets = q_datasets.filter(id__in=set(dataset_pks))
 

--- a/weblab/fitting/views.py
+++ b/weblab/fitting/views.py
@@ -74,6 +74,17 @@ class FittingSpecResultsMatrixView(EntityTypeMixin, DetailView):
         return FittingSpec.objects.visible_to_user(self.request.user)
 
 
+class FittingSpecResultsMatrixJsonView(SingleObjectMixin, View):
+    def get_queryset(self):
+        return FittingSpec.objects.visible_to_user(self.request.user)
+
+    def get(self, request, *args, **kwargs):
+        spec = self.get_object()
+        return JsonResponse({
+            'getMatrix': {}
+        })
+
+
 class FittingResultVersionListView(VisibilityMixin, DetailView):
     """Show all versions of a fitting result"""
     model = FittingResult

--- a/weblab/fitting/views.py
+++ b/weblab/fitting/views.py
@@ -118,9 +118,9 @@ class FittingSpecResultsMatrixJsonView(SingleObjectMixin, ExperimentMatrixJsonVi
         user = request.user
         spec = self.get_object()
         model_pks = list(map(int, request.GET.getlist('modelIds[]')))
-        dataset_pks = list(map(int, request.GET.getlist('datasetIds[]')))
+        dataset_pks = list(map(int, request.GET.getlist('columnIds[]')))
         model_versions = request.GET.getlist('modelVersions[]')
-        subset = request.GET.get('subset', 'moderated')
+        subset = request.GET.get('subset', 'all' if model_pks or dataset_pks else 'moderated')
 
         if model_versions and len(model_pks) > 1:
             return JsonResponse({

--- a/weblab/fitting/views.py
+++ b/weblab/fitting/views.py
@@ -67,6 +67,13 @@ class FittingSpecRenameView(RenameView):
     form_class = FittingSpecRenameForm
 
 
+class FittingSpecResultsMatrixView(EntityTypeMixin, DetailView):
+    template_name = 'fitting/fittingspec_results_matrix.html'
+
+    def get_queryset(self):
+        return FittingSpec.objects.visible_to_user(self.request.user)
+
+
 class FittingResultVersionListView(VisibilityMixin, DetailView):
     """Show all versions of a fitting result"""
     model = FittingResult

--- a/weblab/fitting/views.py
+++ b/weblab/fitting/views.py
@@ -306,7 +306,8 @@ class FittingResultDeleteView(dataset_views.DatasetDeleteView):
     model = FittingResult
 
     def get_success_url(self, *args, **kwargs):
-        return reverse('experiments:list') + '?show_fits=true'
+        obj = self.get_object()
+        return reverse('fitting:matrix', args=[FittingSpec.url_type, obj.fittingspec.id])
 
 
 class FittingResultVersionDeleteView(dataset_views.DatasetDeleteView):

--- a/weblab/fitting/views.py
+++ b/weblab/fitting/views.py
@@ -117,9 +117,9 @@ class FittingSpecResultsMatrixJsonView(SingleObjectMixin, ExperimentMatrixJsonVi
     def get(self, request, *args, **kwargs):
         user = request.user
         spec = self.get_object()
-        model_pks = list(map(int, request.GET.getlist('modelIds[]')))
+        model_pks = list(map(int, request.GET.getlist('rowIds[]')))
         dataset_pks = list(map(int, request.GET.getlist('columnIds[]')))
-        model_versions = request.GET.getlist('modelVersions[]')
+        model_versions = request.GET.getlist('rowVersions[]')
         subset = request.GET.get('subset', 'all' if model_pks or dataset_pks else 'moderated')
 
         if model_versions and len(model_pks) > 1:
@@ -241,8 +241,7 @@ class FittingSpecResultsMatrixJsonView(SingleObjectMixin, ExperimentMatrixJsonVi
 
         return JsonResponse({
             'getMatrix': {
-                'columnType': 'dataset',
-                'models': model_versions,
+                'rows': model_versions,
                 'columns': datasets,
                 'experiments': fittingresults
             }

--- a/weblab/static/js/db.js
+++ b/weblab/static/js/db.js
@@ -528,7 +528,7 @@ function parseLocation ()
   }
   if (rest.length > 0)
   {
-    var items = rest.split("/"),
+    var items = rest.replace(/^\//, "").split("/"),
     modelIndex = items.indexOf("models"),
     protoIndex = items.indexOf("protocols");
     if (protoIndex != -1)

--- a/weblab/static/js/db.js
+++ b/weblab/static/js/db.js
@@ -161,7 +161,7 @@ function drawMatrix (matrix)
 	
 	var div = document.getElementById("matrixdiv"),
 		table = document.createElement("table");
-	$(div).empty();
+	$(div).data('column-type', matrix.columnType).empty();
 	table.setAttribute("class", "matrixTable");
 	div.appendChild(table);
 
@@ -193,16 +193,16 @@ function drawMatrix (matrix)
 				var d1 = document.createElement("div"),
 					d2 = document.createElement("div"),
 					a = document.createElement("a"),
-					proto = mat[0][col].column;
-        a.href = proto.url;
+					column = mat[0][col].column;
+        a.href = column.url;
 				d2.setAttribute("class", "vertical-text");
 				d1.setAttribute("class", "vertical-text__inner");
 				d2.appendChild(d1);
-				a.appendChild(document.createTextNode(proto.name));
+				a.appendChild(document.createTextNode(column.name));
 				d1.appendChild(a);
 				td.appendChild(d2);
 				$td.addClass("matrixTableCol")
-					.data({col: col, protoId: proto.entityId, protoVersion: proto.id})
+					.data({col: col, columnId: column.entityId, columnVersion: column.id})
 					.click(function (ev) {
 						if (comparisonMode) {
 							ev.preventDefault();
@@ -681,13 +681,20 @@ function prepareMatrix ()
 
     if (linesToCompare.col.length > 0)
     {
+      var colType = $(div).data('column-type');
       var cols = linesToCompare.col.map(i => $("#matrix-entry--1-" + i));
-      var protoIds = cols.map($col => $col.data('protoId'));
-      var protoVersions = cols.map($col => $col.data('protoVersion'));
-      if (components.protoVersions) {
-        url += '/protocols/' + protoIds[0] + '/versions/' + protoVersions.join('/');
-      } else {
-        url += '/protocols/' + protoIds.join('/');
+
+      if (colType == 'dataset') {
+        var datasetIds = cols.map($col => $col.data('columnId'));
+        url += '/datasets/' + datasetIds.join('/');
+      } else if (colType == 'protocol') {
+        var protoIds = cols.map($col => $col.data('columnId'));
+        var protoVersions = cols.map($col => $col.data('columnVersion'));
+        if (components.protoVersions) {
+          url += '/protocols/' + protoIds[0] + '/versions/' + protoVersions.join('/');
+        } else {
+          url += '/protocols/' + protoIds.join('/');
+        }
       }
     }
     else

--- a/weblab/static/js/db.js
+++ b/weblab/static/js/db.js
@@ -218,16 +218,6 @@ function drawMatrix (matrix)
 }
 
 
-function encodeQueryData(data) {
-  const ret = [];
-  for (var d in data) {
-    if (data.hasOwnProperty(d)) {
-      ret.push(encodeURIComponent(d) + '=' + encodeURIComponent(data[d]));
-    }
-  }
-  return ret.join('&');
-}
-
 /**
  * Set up the click/hover listeners for the given matrix entry
  * @param $td  the table cell
@@ -247,7 +237,7 @@ function setExpListeners($td, entry)
     if (experimentType == 'fitting') {
       // Link through to fitting submission form
       $td.click(function() {
-        var link = '/fitting/results/new?';
+        var link = $div.data('new-fitting-href') + '?';
         var params = {
           'model': entry.rowData.entityId,
           'model_version': entry.rowData.id,
@@ -257,7 +247,7 @@ function setExpListeners($td, entry)
           'fittingspec': $div.data('fittingspec-id'),
           'fittingspec_version': $div.data('fittingspec-version'),
         }
-        location.href = link + encodeQueryData(params);
+        location.href = link + $.param(params);
       });
     } else {
       // Submit new experiment directly
@@ -525,7 +515,7 @@ function parseLocation ()
 
     if (rowIndex != -1)
     {
-      baseUrls.row = "/models/" + ret.rowIds.join("/");
+      baseUrls.row = "/" + rowUrlFragment + "/" + ret.rowIds.join("/");
     }
     if (colIndex != -1)
     {

--- a/weblab/static/js/db.js
+++ b/weblab/static/js/db.js
@@ -477,14 +477,6 @@ function parseLocation ()
 
   $('.showButton').removeClass("selected");
   $('.showMyButton').hide();
-  if (queryParams.has('show_fits')) {
-    ret.show_fits = true;
-    $('#showFittingExpts').addClass("selected");
-    $('#showPredictionExpts').removeClass("selected");
-  } else {
-    $('#showPredictionExpts').addClass("selected");
-    $('#showFittingExpts').removeClass("selected");
-  }
   if (rest.length > 0)
   {
     var rowUrlFragment = rowType + 's',
@@ -688,14 +680,8 @@ function prepareMatrix ()
     return url + '?';
   }
 
-  function getFittingParams() {
-    params = {};
-    if ($('#showFittingExpts').hasClass("selected")) params['show_fits'] = true;
-    return params;
-  }
-
   function hideModeratedParams(hideModels, hideProtocols, hideDatasets) {
-    var params = getFittingParams();
+    var params = {};
     if (hideModels) params['moderated-models'] = false;
     if (hideProtocols) params['moderated-protocols'] = false;
     if (hideDatasets) params['moderated-datasets'] = false;
@@ -708,7 +694,7 @@ function prepareMatrix ()
         {
             $('.showButton').removeClass("selected");
             $(this).addClass("selected");
-			document.location.href = getBaseUrl() + $.param(getFittingParams());
+			document.location.href = getBaseUrl();
         }
 	});
 	$("#showPublicExpts").click(function () {
@@ -716,7 +702,7 @@ function prepareMatrix ()
         {
             $('.showButton').removeClass("selected");
             $(this).addClass("selected");
-			document.location.href = getBaseUrl() + $.param(getFittingParams());
+			document.location.href = getBaseUrl();
         }
 	});
 	$("#showAllExpts").click(function () {
@@ -724,7 +710,7 @@ function prepareMatrix ()
         {
             $('.showButton').removeClass("selected");
             $(this).addClass("selected");
-			document.location.href = getBaseUrl() + $.param(getFittingParams());
+			document.location.href = getBaseUrl();
         }
 	});
 	$("#showMyExpts").click(function () {
@@ -732,7 +718,7 @@ function prepareMatrix ()
         {
             $('.showButton').removeClass("selected");
             $(this).addClass("selected");
-			document.location.href = getBaseUrl() + $.param(getFittingParams());
+			document.location.href = getBaseUrl();
         }
 	});
 	$("#showMyExptsModels").click(function () {
@@ -753,12 +739,6 @@ function prepareMatrix ()
 			hideProtocols = $("#showMyExptsProtocols").text().substr(0,4) == 'Show';
 			document.location.href = getBaseUrl() + $.param(hideModeratedParams(hideModels, hideProtocols, hideDatasets));
 	});
-
-    // Hacky fitting experiment support
-    $('.showFitsButton').click(function() {
-        $('.showFitsButton').toggleClass("selected");
-        document.location.href = getBaseUrl() + $.param(getFittingParams());
-    });
 }
 
 /**

--- a/weblab/static/js/db.js
+++ b/weblab/static/js/db.js
@@ -288,19 +288,10 @@ function setExpListeners($td, entry)
 	}
 	else
 	{
-    if (entry.protocol) {
-      $td.click(function () {
-        submitNewExperiment ({
-          task: "newExperiment",
-          model: entry.rowData.entityId,
-          model_version: entry.rowData.id,
-          protocol: entry.columnData.entityId,
-          protocol_version: entry.columnData.id,
-        }, $td, entry);
-      });
-    } else {
-	    var $div = $("#matrixdiv");
-
+	  var $div = $("#matrixdiv");
+    var experimentType = $div.data('experiment-type');
+    if (experimentType == 'fitting') {
+      // Link through to fitting submission form
       $td.click(function() {
         var link = '/fitting/results/new?';
         var params = {
@@ -313,7 +304,17 @@ function setExpListeners($td, entry)
           'fittingspec_version': $div.data('fittingspec-version'),
         }
         location.href = link + encodeQueryData(params);
-
+      });
+    } else {
+      // Submit new experiment directly
+      $td.click(function () {
+        submitNewExperiment ({
+          task: "newExperiment",
+          model: entry.rowData.entityId,
+          model_version: entry.rowData.id,
+          protocol: entry.columnData.entityId,
+          protocol_version: entry.columnData.id,
+        }, $td, entry);
       });
     }
 	}

--- a/weblab/static/js/db.js
+++ b/weblab/static/js/db.js
@@ -599,6 +599,7 @@ function parseLocation ()
 
         $('#showMyExptsModels').text("Hide moderated models");
         $('#showMyExptsProtocols').text("Hide moderated protocols");
+        $('#showMyExptsDatasets').text("Hide moderated datasets");
 
         var query = location.search.substr(1);
         var result = {};
@@ -611,6 +612,10 @@ function parseLocation ()
           if (item[0] == 'moderated-protocols' && item[1] == 'false') {
             ret["moderated-protocols"] = "false";
             $('#showMyExptsProtocols').text("Show moderated protocols");
+          }
+          if (item[0] == 'moderated-datasets' && item[1] == 'false') {
+            ret["moderated-datasets"] = "false";
+            $('#showMyExptsDatasets').text("Show moderated datasets");
           }
           result[item[0]] = decodeURIComponent(item[1]);
         });
@@ -737,10 +742,11 @@ function prepareMatrix ()
     return params;
   }
 
-  function hideModeratedParams(hideModels, hideProtocols) {
+  function hideModeratedParams(hideModels, hideProtocols, hideDatasets) {
     var params = getFittingParams();
     if (hideModels) params['moderated-models'] = false;
     if (hideProtocols) params['moderated-protocols'] = false;
+    if (hideDatasets) params['moderated-datasets'] = false;
     return params;
   }
 
@@ -780,12 +786,20 @@ function prepareMatrix ()
 	$("#showMyExptsModels").click(function () {
 		var hideModels = hiddenToggle($(this)),
 			hideProtocols = $("#showMyExptsProtocols").text().substr(0,4) == 'Show';
-			document.location.href = getBaseUrl() + $.param(hideModeratedParams(hideModels, hideProtocols));
+			hideDatasets = $("#showMyExptsDatasets").text().substr(0,4) == 'Show';
+			document.location.href = getBaseUrl() + $.param(hideModeratedParams(hideModels, hideProtocols, hideDatasets));
 	});
 	$("#showMyExptsProtocols").click(function () {
 		var hideProtocols = hiddenToggle($(this)),
 			hideModels = $("#showMyExptsModels").text().substr(0,4) == 'Show';
-			document.location.href = getBaseUrl() + $.param(hideModeratedParams(hideModels, hideProtocols));
+			hideDatasets = $("#showMyExptsDatasets").text().substr(0,4) == 'Show';
+			document.location.href = getBaseUrl() + $.param(hideModeratedParams(hideModels, hideProtocols, hideDatasets));
+	});
+	$("#showMyExptsDatasets").click(function () {
+		var hideDatasets = hiddenToggle($(this)),
+			hideModels = $("#showMyExptsModels").text().substr(0,4) == 'Show';
+			hideProtocols = $("#showMyExptsProtocols").text().substr(0,4) == 'Show';
+			document.location.href = getBaseUrl() + $.param(hideModeratedParams(hideModels, hideProtocols, hideDatasets));
 	});
 
     // Hacky fitting experiment support

--- a/weblab/templates/entities/compare_fittings.html
+++ b/weblab/templates/entities/compare_fittings.html
@@ -74,6 +74,7 @@
         <button id="entityexperimentlist_showallversions">show all model versions</button>
         {% endif %}
         <button id="entityexperimentlistpartnersactcompare" data-base-href="{% url_fitting_comparison_base %}">compare selected fittings</button>
+        <a class="button" href="{% url "fitting:matrix" 'spec' entity.id %}" title="View results for this fitting spec as a matrix">view as matrix</a>
       </div>
     </div>
 {% endblock content_detail %}

--- a/weblab/templates/entities/entity_version.html
+++ b/weblab/templates/entities/entity_version.html
@@ -68,7 +68,7 @@
         <li><a href="{{ entity|url_compare_experiments:version }}" title="Compare experiment results of {% if type == 'model' %}protocols run on this model version{% else %}this protocol version run on different models{% endif %}">Results with different {{ other_type }}s</a></li>
         <li><a href="{{ entity|url_version_comparison_matrix }}" title="Compare experiment results from other versions of this {{ type }}">Results from other versions</a></li>
         {% else %}
-        <li><a href="{% url "fitting:matrix" 'spec' entity.id %}" title="Compare fitting results run with this spec">Results for this spec</a></li>
+        <li><a href="{% url "fitting:matrix" 'spec' entity.id %}" title="Compare fitting results run with this spec">Fitting results for this spec</a></li>
         {% endif %}
         <li><a href="{% entity_url 'version_list' entity %}" title="Show differences between versions of this {{ type }}">Other versions</a></li>
       </ul></div>

--- a/weblab/templates/entities/entity_version.html
+++ b/weblab/templates/entities/entity_version.html
@@ -67,6 +67,8 @@
         {% if type == 'model' or type == 'protocol' %}
         <li><a href="{{ entity|url_compare_experiments:version }}" title="Compare experiment results of {% if type == 'model' %}protocols run on this model version{% else %}this protocol version run on different models{% endif %}">Results with different {{ other_type }}s</a></li>
         <li><a href="{{ entity|url_version_comparison_matrix }}" title="Compare experiment results from other versions of this {{ type }}">Results from other versions</a></li>
+        {% else %}
+        <li><a href="{% url "fitting:matrix" 'spec' entity.id %}" title="Compare fitting results run with this spec">Results for this spec</a></li>
         {% endif %}
         <li><a href="{% entity_url 'version_list' entity %}" title="Show differences between versions of this {{ type }}">Other versions</a></li>
       </ul></div>

--- a/weblab/templates/experiments/experiments.html
+++ b/weblab/templates/experiments/experiments.html
@@ -18,9 +18,6 @@
           <button class="showButton showMyButton" id="showMyExptsModels" title="Select whether to include moderated models, or just those owned by you">Hide moderated models</button>
           <button class="showButton showMyButton" id="showMyExptsProtocols" title="Select whether to include moderated protocols, or just those owned by you">Hide moderated protocols</button>
       {% endif %}
-      <br />
-      <button class="showFitsButton" id="showPredictionExpts">Show simulation experiments</button>
-      <button class="showFitsButton" id="showFittingExpts">Show parameter fitting experiments</button>
     </p>
     <p>
     This matrix shows the latest versions (visible to you) of the models and protocols in our database, with the corresponding experiments.

--- a/weblab/templates/experiments/experiments.html
+++ b/weblab/templates/experiments/experiments.html
@@ -42,7 +42,11 @@
         <button id="comparisonMatrix" title="Show matrix featuring only selected models and/or protocols">Show sub-matrix</button>
     </span>
     </p>
-    <div id="matrixdiv" data-base-json-href="{% url 'experiments:matrix' %}" data-base-href="{% url 'experiments:list' %}"></div>
+    <div id="matrixdiv"
+      data-base-json-href="{% url 'experiments:matrix' %}"
+      data-base-href="{% url 'experiments:list' %}"
+      data-column-type="protocol"
+      ></div>
     <br/>
     Key:
     <table class="matrixTable small">

--- a/weblab/templates/experiments/experiments.html
+++ b/weblab/templates/experiments/experiments.html
@@ -45,6 +45,7 @@
     <div id="matrixdiv"
       data-base-json-href="{% url 'experiments:matrix' %}"
       data-base-href="{% url 'experiments:list' %}"
+      data-row-type="model"
       data-column-type="protocol"
       ></div>
     <br/>

--- a/weblab/templates/experiments/experiments.html
+++ b/weblab/templates/experiments/experiments.html
@@ -47,6 +47,7 @@
       data-base-href="{% url 'experiments:list' %}"
       data-row-type="model"
       data-column-type="protocol"
+      data-experiment-type="experiment"
       ></div>
     <br/>
     Key:

--- a/weblab/templates/fitting/fittingspec_results_matrix.html
+++ b/weblab/templates/fitting/fittingspec_results_matrix.html
@@ -5,7 +5,7 @@
 {% block title %}Fitting Experiments - {{ fittingspec.name }}{% endblock title %}
 
 {% block content %}
-<h1>Available fitting experiments for {{ fittingspec.name }}</h1>
+<h1>Available fitting experiments for <a href="{% url "fitting:detail" "spec" fittingspec.id %}">{{ fittingspec.name }}</a></h1>
 
   <section id="matrixTab">
     <p>

--- a/weblab/templates/fitting/fittingspec_results_matrix.html
+++ b/weblab/templates/fitting/fittingspec_results_matrix.html
@@ -51,6 +51,7 @@
       data-fittingspec-version="{{ fittingspec.repocache.latest_version.sha }}"
       data-row-type="model"
       data-column-type="dataset"
+      data-experiment-type="fitting"
       >
     </div>
     <br/>

--- a/weblab/templates/fitting/fittingspec_results_matrix.html
+++ b/weblab/templates/fitting/fittingspec_results_matrix.html
@@ -43,7 +43,13 @@
         <button id="comparisonMatrix" title="Show matrix featuring only selected models and/or datasets">Show sub-matrix</button>
     </span>
     </p>
-    <div id="matrixdiv" data-base-json-href="{% url 'fitting:matrix_json' 'spec' fittingspec.id %}" data-base-href="{% url 'experiments:list' %}"></div>
+    <div id="matrixdiv"
+      data-base-json-href="{% url 'fitting:matrix_json' 'spec' fittingspec.id %}"
+      data-base-href="{% url 'experiments:list' %}"
+      data-fittingspec-id="{{ fittingspec.id }}"
+      data-fittingspec-version="{{ fittingspec.repocache.latest_version.sha }}"
+      >
+    </div>
     <br/>
     Key:
     <table class="matrixTable small">

--- a/weblab/templates/fitting/fittingspec_results_matrix.html
+++ b/weblab/templates/fitting/fittingspec_results_matrix.html
@@ -45,7 +45,7 @@
     </p>
     <div id="matrixdiv"
       data-base-json-href="{% url 'fitting:matrix_json' 'spec' fittingspec.id %}"
-      data-base-href="{% url 'experiments:list' %}"
+      data-base-href="{% url 'fitting:matrix' 'spec' fittingspec.id %}"
       data-fittingspec-id="{{ fittingspec.id }}"
       data-fittingspec-version="{{ fittingspec.repocache.latest_version.sha }}"
       >

--- a/weblab/templates/fitting/fittingspec_results_matrix.html
+++ b/weblab/templates/fitting/fittingspec_results_matrix.html
@@ -49,6 +49,7 @@
       data-base-href="{% url 'fitting:matrix' 'spec' fittingspec.id %}"
       data-fittingspec-id="{{ fittingspec.id }}"
       data-fittingspec-version="{{ fittingspec.repocache.latest_version.sha }}"
+      data-column-type="dataset"
       >
     </div>
     <br/>

--- a/weblab/templates/fitting/fittingspec_results_matrix.html
+++ b/weblab/templates/fitting/fittingspec_results_matrix.html
@@ -21,7 +21,6 @@
       {% endif %}
     </p>
     {% comment %}
-      <p>
       This matrix shows the latest versions (visible to you) of the models and dataset in our database, with the corresponding experiments.
       {% if perms.create_experiment %}
         If you can't see experiments you expect to be there, this is probably because they are associated with an older version of a listed model or protocol.
@@ -35,8 +34,10 @@
       <p>
       Alternatively, enable 'comparison mode' to allow selecting arbitrary experiments from this matrix view to compare.
       Click on a column or row heading to select the entire column or row.<br/>
+   {% endcomment %}
+    <p>
       Comparison mode: <button id="comparisonModeButton"></button>
-    {% endcomment %}
+    </p>
 
     <span id="comparisonModeActions">
         <button id="comparisonLink" data-comparison-href="{% url_fitting_comparison_base %}">Compare selected fitting results</button>

--- a/weblab/templates/fitting/fittingspec_results_matrix.html
+++ b/weblab/templates/fitting/fittingspec_results_matrix.html
@@ -49,6 +49,7 @@
       data-base-href="{% url 'fitting:matrix' 'spec' fittingspec.id %}"
       data-fittingspec-id="{{ fittingspec.id }}"
       data-fittingspec-version="{{ fittingspec.repocache.latest_version.sha }}"
+      data-new-fitting-href="{% url 'fitting:result:new' %}"
       data-row-type="model"
       data-column-type="dataset"
       data-experiment-type="fitting"

--- a/weblab/templates/fitting/fittingspec_results_matrix.html
+++ b/weblab/templates/fitting/fittingspec_results_matrix.html
@@ -43,9 +43,7 @@
         <button id="comparisonMatrix" title="Show matrix featuring only selected models and/or datasets">Show sub-matrix</button>
     </span>
     </p>
-    {% comment %}
-    <div id="matrixdiv" data-base-json-href="{% url 'experiments:matrix' %}" data-base-href="{% url 'experiments:list' %}"></div>
-    {% endcomment %}
+    <div id="matrixdiv" data-base-json-href="{% url 'fitting:matrix_json' 'spec' fittingspec.id %}" data-base-href="{% url 'experiments:list' %}"></div>
     <br/>
     Key:
     <table class="matrixTable small">

--- a/weblab/templates/fitting/fittingspec_results_matrix.html
+++ b/weblab/templates/fitting/fittingspec_results_matrix.html
@@ -49,6 +49,7 @@
       data-base-href="{% url 'fitting:matrix' 'spec' fittingspec.id %}"
       data-fittingspec-id="{{ fittingspec.id }}"
       data-fittingspec-version="{{ fittingspec.repocache.latest_version.sha }}"
+      data-row-type="model"
       data-column-type="dataset"
       >
     </div>

--- a/weblab/templates/fitting/fittingspec_results_matrix.html
+++ b/weblab/templates/fitting/fittingspec_results_matrix.html
@@ -1,0 +1,71 @@
+{% extends "base.html" %}
+{% load experiments %}
+{% load fittings %}
+
+{% block title %}Fitting Experiments - {{ fittingspec.name }}{% endblock title %}
+
+{% block content %}
+<h1>Available fitting experiments for {{ fittingspec.name }}</h1>
+
+  <section id="matrixTab">
+    <p>
+      Show:
+      <button class="showButton" id="showModeratedExpts" data-suffix="" title="Only show experiments where the model and dataset have been approved by a site admin">Moderated experiments</button>
+      <button class="showButton" id="showPublicExpts" data-suffix="public">All public experiments</button>
+      {% if user.is_authenticated %}
+          <button class="showButton" id="showAllExpts" title="Show all experiments I have permissions to see" data-suffix="all">All visible experiments</button>
+          <button class="showButton" id="showMyExpts" data-suffix="mine">My experiments</button>
+          <br/>
+          <button class="showButton showMyButton" id="showMyExptsModels" title="Select whether to include moderated models, or just those owned by you">Hide moderated models</button>
+          <button class="showButton showMyButton" id="showMyExptsDatasets" title="Select whether to include moderated datasets, or just those owned by you">Hide moderated datasets</button>
+      {% endif %}
+    </p>
+    {% comment %}
+      <p>
+      This matrix shows the latest versions (visible to you) of the models and dataset in our database, with the corresponding experiments.
+      {% if perms.create_experiment %}
+        If you can't see experiments you expect to be there, this is probably because they are associated with an older version of a listed model or protocol.
+        You can click on the white squares to launch experiments using the latest versions.
+      {% endif %}
+      </p>
+      <p>
+      Note that you can compare models' behaviours under a particular protocol by viewing the protocol (click on a column heading), selecting the 'Compare models' button, and comparing the experiments using models of interest.
+      The converse comparison (one model, many protocols) is available via viewing a model.
+      </p>
+      <p>
+      Alternatively, enable 'comparison mode' to allow selecting arbitrary experiments from this matrix view to compare.
+      Click on a column or row heading to select the entire column or row.<br/>
+      Comparison mode: <button id="comparisonModeButton"></button>
+    {% endcomment %}
+
+    <span id="comparisonModeActions">
+        <button id="comparisonLink" data-comparison-href="{% url_fitting_comparison_base %}">Compare selected fitting results</button>
+        <button id="comparisonMatrix" title="Show matrix featuring only selected models and/or datasets">Show sub-matrix</button>
+    </span>
+    </p>
+    {% comment %}
+    <div id="matrixdiv" data-base-json-href="{% url 'experiments:matrix' %}" data-base-href="{% url 'experiments:list' %}"></div>
+    {% endcomment %}
+    <br/>
+    Key:
+    <table class="matrixTable small">
+        <tr>
+            <td class="center">not run</td>
+            <td class="experiment-QUEUED center">queued</td>
+            <td class="experiment-RUNNING center">running</td>
+            <td class="experiment-SUCCESS center">ran to completion</td>
+            <td class="experiment-PARTIAL center">partially ran</td>
+            <td class="experiment-FAILED center">did not complete</td>
+            <td class="experiment-INAPPLICABLE center">inapplicable</td>
+        </tr>
+    </table>
+    <p>
+    {% comment %}
+      An 'inapplicable' experiment is one where the model does not contain some biological feature probed by the protocol.
+      Experiments show as red if no graphs are available, green if all those expected from the protocol description are generated.
+      Note that no comparison is done against experimental data, and so the colours do <strong>not</strong> indicate model 'correctness' in any sense.
+    {% endcomment %}
+    </p>
+  </section>
+
+{% endblock content %}


### PR DESCRIPTION
Fitting results matrix

This is for #278 

* One per fitting spec, with models on rows and datasets on columns
* Javascript adapted to row/column rather than model/protocol so it can generically handle fitting or simulation experiments (and columns need not have versions)
* Click cell goes through to fitting results form (rather than starting an experiment directly, as with the original matrix)

I've removed the old hacky UI elements for showing fittings in a matrix, although the relevant database fields are still in place.