### PR TITLE
Fitting matrix improvements

### DIFF
--- a/weblab/fitting/tests/test_views.py
+++ b/weblab/fitting/tests/test_views.py
@@ -1054,11 +1054,11 @@ class TestFittingSpecResultsMatrixJsonView:
     def test_ignores_unrelated_datasets(self, client, helpers):
         related_protocol = recipes.protocol.make()
         helpers.add_fake_version(related_protocol, visibility='public')
-        related_dataset = recipes.dataset.make(protocol=related_protocol)
+        related_dataset = recipes.dataset.make(protocol=related_protocol, visibility='public')
 
         unrelated_protocol = recipes.protocol.make()
         helpers.add_fake_version(unrelated_protocol, visibility='public')
-        unrelated_dataset = recipes.dataset.make(protocol=unrelated_protocol)
+        unrelated_dataset = recipes.dataset.make(protocol=unrelated_protocol, visibility='public')
 
         fittingspec = recipes.fittingspec.make(protocol=related_protocol)
         helpers.add_fake_version(fittingspec, visibility='public')

--- a/weblab/templates/entities/compare_fittings.html
+++ b/weblab/templates/entities/compare_fittings.html
@@ -29,7 +29,7 @@
                     {% if entity.entity_type == 'protocol' %}
                       {{ fitting|name_of_fittingspec }}
                     {% else %}
-                      {{ fitting|name_of_protocol }}
+                      {{ fitting|name_of_protocol }} using {{ fitting|name_of_fittingspec }}
                     {% endif %}
                   </a>
                 </li>

--- a/weblab/templates/entities/compare_fittings.html
+++ b/weblab/templates/entities/compare_fittings.html
@@ -74,7 +74,9 @@
         <button id="entityexperimentlist_showallversions">show all model versions</button>
         {% endif %}
         <button id="entityexperimentlistpartnersactcompare" data-base-href="{% url_fitting_comparison_base %}">compare selected fittings</button>
+        {% if entity.entity_type == 'fittingspec' %}
         <a class="button" href="{% url "fitting:matrix" 'spec' entity.id %}" title="View results for this fitting spec as a matrix">view as matrix</a>
+        {% endif %}
       </div>
     </div>
 {% endblock content_detail %}


### PR DESCRIPTION
Addresses two fixes for feedback raised on #278 
1. remove 'view as matrix' link from model and protocol pages
2. display fitting spec name on model's fitting result lists, to ensure we can distinguish between results

Also contains a fix for an intermittently failing test that was introduced in the original code for this issue. The fix is also in #319 so it's a matter of which of those gets merged first :)