### PR TITLE
add author name to entity list view

### DIFF
--- a/weblab/templates/entities/entity_list.html
+++ b/weblab/templates/entities/entity_list.html
@@ -23,7 +23,7 @@
     <ul>
       {% for entity in object_list %}
         <li title="{{ entity.name }}">
-          <strong><a href="{% entity_url 'detail' entity %}">{{ entity.name }}</a></strong>
+          <strong><a href="{% entity_url 'detail' entity %}">{{ entity.name }}</strong><em style="margin-right:0.25em"> (by {{ entity.author.full_name }}) </em></a>
 
           {% can_create_version entity as permission %}
           {% if permission %}


### PR DESCRIPTION
I added teh author name in brackets to the entity list view, because models at least can have duplicate names, as long as the authors are different.
Here is an example fo what it'll look like:
![image](https://user-images.githubusercontent.com/52317399/126337961-71622d1a-64fd-4d2b-91fc-9736288c5755.png)