### PR TITLE
Replaced deprecated 'pytest.yield_fixture' with 'pytest.fixture', ...

### DIFF
--- a/requirements/test.in
+++ b/requirements/test.in
@@ -4,6 +4,6 @@ codecov<3
 flake8
 isort<5
 model-bakery==1.2.0
-pytest<7
+pytest>=3,<7
 pytest-django<5
 pytest-cov<3

--- a/weblab/conftest.py
+++ b/weblab/conftest.py
@@ -512,14 +512,14 @@ def fittingresult_with_result(model_with_version, protocol_with_version):
     return version
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def mock_column_names():
     with patch.object(Dataset, 'column_names',
                       new_callable=PropertyMock, return_value=['col']) as mock_col:
         yield mock_col
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def story(logged_in_user, experiment_with_result):
     experiment = experiment_with_result.experiment
     story = recipes.story.make(author=logged_in_user)

--- a/weblab/experiments/tests/test_views.py
+++ b/weblab/experiments/tests/test_views.py
@@ -55,7 +55,7 @@ def archive_file_path():
     return str(Path(__file__).absolute().parent.joinpath('./test.omex'))
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def archive_file(archive_file_path):
     with open(archive_file_path, 'rb') as fp:
         yield fp


### PR DESCRIPTION
...which is equivalent since pytest 3. Closes #384.