### PR TITLE
caching downloaidng experiment version files for graphs

### DIFF
--- a/weblab/experiments/urls.py
+++ b/weblab/experiments/urls.py
@@ -83,6 +83,7 @@ urlpatterns = [
         name='version_json',
     ),
 
+    # Caching should be safe: any changes => new version numer, but these files are the main slowdown in graph loading
     url(
         r'^(?P<experiment_pk>\d+)/versions/(?P<pk>\d+)/download/%s$' % _FILENAME,
         cache_page(None)(views.ExperimentFileDownloadView.as_view()),

--- a/weblab/experiments/urls.py
+++ b/weblab/experiments/urls.py
@@ -1,4 +1,5 @@
 from django.conf.urls import url
+from django.views.decorators.cache import cache_page
 
 from . import views
 
@@ -84,7 +85,7 @@ urlpatterns = [
 
     url(
         r'^(?P<experiment_pk>\d+)/versions/(?P<pk>\d+)/download/%s$' % _FILENAME,
-        views.ExperimentFileDownloadView.as_view(),
+        cache_page(None)(views.ExperimentFileDownloadView.as_view()),
         name='file_download',
     ),
 


### PR DESCRIPTION
Switched on caching for downloading teh files for graphs. Could possibly consider caching more things, but this is the main slowdown it sees and we're pretty sure that any changes => new version number so should be quite safe to do.