### PR TITLE
downgraded gitpython in requirements

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -2,10 +2,10 @@ name: build
 on: [pull_request]
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
     steps:
     - name: Start PostgreSQL on Ubuntu
       run: |

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -10,7 +10,8 @@ social-auth-app-django==4.0.0
 dj-database-url==0.4.2
 
 # Git repo management
-GitPython==3.1.18
+GitPython==3.1.18; python_version < '2.7'
+GitPython==3.1.30; python_version >= '2.7'
 
 # django helpers
 django-braces==1.14.0

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -10,8 +10,8 @@ social-auth-app-django==4.0.0
 dj-database-url==0.4.2
 
 # Git repo management
-GitPython==3.1.18; python_version < '2.7'
-GitPython==3.1.30; python_version >= '2.7'
+GitPython==3.1.18; python_version == '2.6'
+GitPython==3.1.30; python_version != '2.6'
 
 # django helpers
 django-braces==1.14.0

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -10,7 +10,7 @@ social-auth-app-django==4.0.0
 dj-database-url==0.4.2
 
 # Git repo management
-GitPython==3.1.30
+GitPython==3.1.18
 
 # django helpers
 django-braces==1.14.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -27,7 +27,7 @@ django-braces==1.14.0
     # via -r base.in
 django-guardian==2.3.0
     # via -r base.in
-gitdb==4.0.7
+gitdb==4.0.9
     # via gitpython
 gitpython==3.1.18
     # via -r base.in

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -27,11 +27,11 @@ django-braces==1.14.0
     # via -r base.in
 django-guardian==2.3.0
     # via -r base.in
-gitdb==4.0.9; python_version < '2.7'
-gitdb==4.0.10; python_version >= '2.7'
+gitdb==4.0.9; python_version == '2.6'
+gitdb==4.0.10; python_version > '2.6'
     # via gitpython
-gitpython==3.1.18; python_version < '2.7'
-gitPython==3.1.30; python_version >= '2.7'
+gitpython==3.1.18; python_version == '2.6'
+gitPython==3.1.30; python_version > '2.6'
     # via -r base.in
 idna==2.10
     # via requests

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -27,9 +27,11 @@ django-braces==1.14.0
     # via -r base.in
 django-guardian==2.3.0
     # via -r base.in
-gitdb==4.0.9
+gitdb==4.0.9; python_version < '2.7'
+gitdb==4.0.10; python_version >= '2.7'
     # via gitpython
-gitpython==3.1.18
+gitpython==3.1.18; python_version < '2.7'
+gitPython==3.1.30; python_version >= '2.7'
     # via -r base.in
 idna==2.10
     # via requests

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -29,7 +29,7 @@ django-guardian==2.3.0
     # via -r base.in
 gitdb==4.0.7
     # via gitpython
-gitpython==3.1.30
+gitpython==3.1.18
     # via -r base.in
 idna==2.10
     # via requests

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -47,7 +47,7 @@ django-guardian==2.3.0
     # via -r base.in
 flake8==3.9.2
     # via -r test.in
-gitdb==4.0.7
+gitdb==4.0.9
     # via gitpython
 gitpython==3.1.30
     # via -r base.in

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -75,7 +75,7 @@ oauthlib==3.2.1
     # via
     #   requests-oauthlib
     #   social-auth-core
-packaging==20.9
+packaging==21.3
     # via pytest
 parso==0.8.2
     # via jedi

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -18,7 +18,7 @@ click==8.0.1
     # via pip-tools
 codecov==2.1.11
     # via -r test.in
-coverage==5.5
+coverage==6.2
     # via
     #   codecov
     #   pytest-cov

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -49,7 +49,7 @@ flake8==3.9.2
     # via -r test.in
 gitdb==4.0.9
     # via gitpython
-gitpython==3.1.30
+gitpython==3.1.18
     # via -r base.in
 idna==2.10
     # via requests

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -18,7 +18,7 @@ click==8.0.1
     # via pip-tools
 codecov==2.1.11
     # via -r test.in
-coverage==6.2
+`
     # via
     #   codecov
     #   pytest-cov
@@ -47,9 +47,11 @@ django-guardian==2.3.0
     # via -r base.in
 flake8==3.9.2
     # via -r test.in
-gitdb==4.0.9
+gitdb==4.0.9; python_version < '2.7'
+gitdb==4.0.10; python_version >= '2.7'
     # via gitpython
-gitpython==3.1.18
+gitpython==3.1.18; python_version < '2.7'
+gitPython==3.1.30; python_version >= '2.7'
     # via -r base.in
 idna==2.10
     # via requests
@@ -75,7 +77,8 @@ oauthlib==3.2.1
     # via
     #   requests-oauthlib
     #   social-auth-core
-packaging==21.3
+packaging==21.3; python_version < '2.7'
+packaging==23.0; python_version >= '2.7'
     # via pytest
 parso==0.8.2
     # via jedi

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -47,11 +47,11 @@ django-guardian==2.3.0
     # via -r base.in
 flake8==3.9.2
     # via -r test.in
-gitdb==4.0.9; python_version < '2.7'
-gitdb==4.0.10; python_version >= '2.7'
+gitdb==4.0.9; python_version == '2.6'
+gitdb==4.0.10; python_version != '2.6'
     # via gitpython
-gitpython==3.1.18; python_version < '2.7'
-gitPython==3.1.30; python_version >= '2.7'
+gitpython==3.1.18; python_version == '2.6'
+gitPython==3.1.30; python_version != '2.6'
     # via -r base.in
 idna==2.10
     # via requests
@@ -77,8 +77,8 @@ oauthlib==3.2.1
     # via
     #   requests-oauthlib
     #   social-auth-core
-packaging==21.3; python_version < '2.7'
-packaging==23.0; python_version >= '2.7'
+packaging==21.3; python_version == '2.6'
+packaging==23.0; python_version != '2.6'
     # via pytest
 parso==0.8.2
     # via jedi

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -27,7 +27,7 @@ py==1.11.0
 pycodestyle==2.7.0
 pycparser==2.21
 pyflakes==2.3.1
-pyjwt==2.6.0
+pyjwt==2.4.0
 pytest==6.2.4
 pytest-cov==2.12.1
 pytest-django==4.4.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -3,7 +3,7 @@ certifi==2022.12.7
 cffi==1.15.1
 chardet==4.0.0
 codecov==2.1.11
-coverage==7.0.5
+coverage==6.2
 cryptography==39.0.0
 defusedxml==0.7.1
 dj-database-url==0.4.2

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -3,8 +3,8 @@ certifi==2022.12.7
 cffi==1.15.1
 chardet==4.0.0
 codecov==2.1.11
-coverage==6.2; python_version < '2.7'
-coverage==7.0.5; python_version >= '2.7'
+coverage==6.2; python_version == '2.6'
+coverage==7.0.5; python_version != '2.6'
 cryptography==39.0.0
 defusedxml==0.7.1
 dj-database-url==0.4.2
@@ -12,19 +12,19 @@ django==2.2.28
 django-braces==1.14.0
 django-guardian==2.3.0
 flake8==3.9.2
-gitdb==4.0.9; python_version < '2.7'
-gitdb==4.0.10; python_version >= '2.7'
-gitpython==3.1.18; python_version < '2.7'
-gitPython==3.1.30; python_version >= '2.7'
+gitdb==4.0.9; python_version == '2.6'
+gitdb==4.0.10; python_version != '2.6'
+gitpython==3.1.18; python_version == '2.6'
+gitPython==3.1.30; python_version != '2.6'
 idna==2.10
-iniconfig==1.1.1; python_version < '2.7'
-iniconfig==2.0.0; python_version >= '2.7'
+iniconfig==1.1.1; python_version == '2.6'
+iniconfig==2.0.0; python_version != '2.6'
 isort==4.3.21
 mccabe==0.6.1
 model-bakery==1.2.0
 oauthlib==3.2.2
-packaging==21.3; python_version < '2.7'
-packaging==23.0; python_version >= '2.7'
+packaging==21.3; python_version == '2.6'
+packaging==23.0; python_version != '2.6'
 pint==0.9
 pluggy==0.13.1
 psycopg2==2.8.6
@@ -33,8 +33,8 @@ pycodestyle==2.7.0
 pycparser==2.21
 pyflakes==2.3.1
 pyjwt==2.4.0
-pyjwt==2.4.0; python_version < '2.7'
-pyjwt==2.6.0; python_version >= '2.7'
+pyjwt==2.4.0; python_version == '2.6'
+pyjwt==2.6.0; python_version != '2.6'
 pytest==6.2.4
 pytest-cov==2.12.1
 pytest-django==4.4.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -14,7 +14,7 @@ flake8==3.9.2
 gitdb==4.0.9
 gitpython==3.1.18
 idna==2.10
-iniconfig==2.0.0
+iniconfig==1.1.1
 isort==4.3.21
 mccabe==0.6.1
 model-bakery==1.2.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -12,7 +12,7 @@ django-braces==1.14.0
 django-guardian==2.3.0
 flake8==3.9.2
 gitdb==4.0.9
-gitpython==3.1.30
+gitpython==3.1.18
 idna==2.10
 iniconfig==2.0.0
 isort==4.3.21

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -3,7 +3,8 @@ certifi==2022.12.7
 cffi==1.15.1
 chardet==4.0.0
 codecov==2.1.11
-coverage==6.2
+coverage==6.2; python_version < '2.7'
+coverage==7.0.5; python_version >= '2.7'
 cryptography==39.0.0
 defusedxml==0.7.1
 dj-database-url==0.4.2
@@ -11,15 +12,19 @@ django==2.2.28
 django-braces==1.14.0
 django-guardian==2.3.0
 flake8==3.9.2
-gitdb==4.0.9
-gitpython==3.1.18
+gitdb==4.0.9; python_version < '2.7'
+gitdb==4.0.10; python_version >= '2.7'
+gitpython==3.1.18; python_version < '2.7'
+gitPython==3.1.30; python_version >= '2.7'
 idna==2.10
-iniconfig==1.1.1
+iniconfig==1.1.1; python_version < '2.7'
+iniconfig==2.0.0; python_version >= '2.7'
 isort==4.3.21
 mccabe==0.6.1
 model-bakery==1.2.0
 oauthlib==3.2.2
-packaging==21.3
+packaging==21.3; python_version < '2.7'
+packaging==23.0; python_version >= '2.7'
 pint==0.9
 pluggy==0.13.1
 psycopg2==2.8.6
@@ -28,6 +33,8 @@ pycodestyle==2.7.0
 pycparser==2.21
 pyflakes==2.3.1
 pyjwt==2.4.0
+pyjwt==2.4.0; python_version < '2.7'
+pyjwt==2.6.0; python_version >= '2.7'
 pytest==6.2.4
 pytest-cov==2.12.1
 pytest-django==4.4.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -11,7 +11,7 @@ django==2.2.28
 django-braces==1.14.0
 django-guardian==2.3.0
 flake8==3.9.2
-gitdb==4.0.10
+gitdb==4.0.9
 gitpython==3.1.30
 idna==2.10
 iniconfig==2.0.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -19,7 +19,7 @@ isort==4.3.21
 mccabe==0.6.1
 model-bakery==1.2.0
 oauthlib==3.2.2
-packaging==23.0
+packaging==21.3
 pint==0.9
 pluggy==0.13.1
 psycopg2==2.8.6


### PR DESCRIPTION
downgraded gitpython in requirements, to latest version that supports python 3.6 as weblab deployment uses ubuntu 18.04 with python 3.6